### PR TITLE
BS-12531 : For Bonita Performance utilization, one must add "brokerURL" ...

### DIFF
--- a/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/AbstractJMSUpdateHandler.java
+++ b/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/AbstractJMSUpdateHandler.java
@@ -21,6 +21,7 @@ import org.bonitasoft.engine.transaction.BonitaTransactionSynchronization;
 
 /**
  * @author Baptiste Mesta
+ * @author Guillaume Rosinosky
  */
 public abstract class AbstractJMSUpdateHandler extends AbstractUpdateHandler {
 
@@ -28,14 +29,17 @@ public abstract class AbstractJMSUpdateHandler extends AbstractUpdateHandler {
 
     private final Long messageTimeout;
 
-    public AbstractJMSUpdateHandler(final long tenantId, final long messageTimeout) {
+    private String brokerURL;
+    
+    public AbstractJMSUpdateHandler(final long tenantId, final long messageTimeout, String brokerURL) {
         super(tenantId);
         this.messageTimeout = messageTimeout;
+        this.brokerURL = brokerURL;
     }
-
+    
     @Override
     protected BonitaTransactionSynchronization getSynchronization(final Map<String, Serializable> event, final Long id,
             final TenantServiceAccessor tenantServiceAccessor) {
-        return new SendJMSMessageSynchronization(event, id, JMSProducer.getInstance(messageTimeout));
+        return new SendJMSMessageSynchronization(event, id, JMSProducer.getInstance(messageTimeout, brokerURL));
     }
 }

--- a/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/AddPerfHandlerCommand.java
+++ b/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/AddPerfHandlerCommand.java
@@ -27,16 +27,18 @@ public class AddPerfHandlerCommand extends TenantCommand {
         final EventService eventService = serviceAccessor.getEventService();
         final Long messageTimeout = (Long) parameters.get("timeout");
 
+        final String brokerURL = (String) parameters.get("brokerURL");
+        
         try {
             final long tenantId = serviceAccessor.getTenantId();
             if (!containsHandler(eventService, PROCESSINSTANCE_STATE_UPDATED, ProcessInstanceFinishedHandler.class)) {
-                eventService.addHandler(PROCESSINSTANCE_STATE_UPDATED, new ProcessInstanceFinishedHandler(tenantId, messageTimeout));
+                eventService.addHandler(PROCESSINSTANCE_STATE_UPDATED, new ProcessInstanceFinishedHandler(tenantId, messageTimeout, brokerURL));
             }
             if (!containsHandler(eventService, ACTIVITYINSTANCE_STATE_UPDATED, TaskReadyHandler.class)) {
-                eventService.addHandler(ACTIVITYINSTANCE_STATE_UPDATED, new TaskReadyHandler(tenantId, messageTimeout));
+                eventService.addHandler(ACTIVITYINSTANCE_STATE_UPDATED, new TaskReadyHandler(tenantId, messageTimeout, brokerURL));
             }
             if (!containsHandler(eventService, ACTIVITYINSTANCE_STATE_UPDATED, FlowNodeReachStateHandler.class)) {
-                eventService.addHandler(ACTIVITYINSTANCE_STATE_UPDATED, new FlowNodeReachStateHandler(tenantId, messageTimeout, 3));
+                eventService.addHandler(ACTIVITYINSTANCE_STATE_UPDATED, new FlowNodeReachStateHandler(tenantId, messageTimeout, brokerURL, 3));
             }
             final EntityUpdateDescriptor entityUpdateDescriptor = new EntityUpdateDescriptor();
             entityUpdateDescriptor.addField("system", true);

--- a/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/FlowNodeReachStateHandler.java
+++ b/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/FlowNodeReachStateHandler.java
@@ -31,8 +31,8 @@ public class FlowNodeReachStateHandler extends AbstractJMSUpdateHandler {
 
     private final int stateId;
 
-    public FlowNodeReachStateHandler(final long tenantId, final long messageTimeout, final int stateId) {
-        super(tenantId, messageTimeout);
+    public FlowNodeReachStateHandler(final long tenantId, final long messageTimeout, String brokerURL, final int stateId) {
+        super(tenantId, messageTimeout, brokerURL);
         this.stateId = stateId;
         identifier = UUID.randomUUID().toString();
     }

--- a/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/JMSProducer.java
+++ b/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/JMSProducer.java
@@ -33,8 +33,12 @@ public class JMSProducer {
 
     private static JMSProducer jmsProducer;
 
-    private JMSProducer(final long timeout) throws JMSException {
-        final String brokerURL = System.getProperty("broker.url");
+  
+    private JMSProducer(final long timeout, String brokerURL) throws JMSException {
+        
+        // if brokerURL not defined before, get property
+        if (brokerURL == null) 
+            brokerURL = System.getProperty("broker.url");
 
         // Create a ConnectionFactory
         topicConnectionFactory = new ActiveMQConnectionFactory(brokerURL);
@@ -62,12 +66,15 @@ public class JMSProducer {
                 }
             }
         });
+        
     }
-
-    public static JMSProducer getInstance(final long messageTimeout) {
+    
+   
+   public static JMSProducer getInstance(final long messageTimeout, final String brokerURL) {
+        // TODO : add map by tenant
         if (jmsProducer == null) {
             try {
-                jmsProducer = new JMSProducer(messageTimeout);
+                jmsProducer = new JMSProducer(messageTimeout, brokerURL);
             } catch (final Exception e) {
                 e.printStackTrace();
                 throw new RuntimeException(e);
@@ -75,7 +82,9 @@ public class JMSProducer {
         }
         return jmsProducer;
     }
-
+    
+    
+    
     public void sendMessage(final Map<String, Serializable> properties, final String bodyId) throws JMSException {
         final MapMessage message = session.createMapMessage();
 

--- a/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/ProcessInstanceFinishedHandler.java
+++ b/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/ProcessInstanceFinishedHandler.java
@@ -23,6 +23,7 @@ import org.bonitasoft.engine.events.model.SEvent;
 
 /**
  * @author Baptiste Mesta
+ * @author Guillaume Rosinosky
  */
 public class ProcessInstanceFinishedHandler extends AbstractJMSUpdateHandler {
 
@@ -30,8 +31,8 @@ public class ProcessInstanceFinishedHandler extends AbstractJMSUpdateHandler {
 
     private final String identifier;
 
-    public ProcessInstanceFinishedHandler(final long tenantId, final long messageTimeout) {
-        super(tenantId, messageTimeout);
+    public ProcessInstanceFinishedHandler(final long tenantId, final long messageTimeout, final String brokerURL) {
+        super(tenantId, messageTimeout, brokerURL);
         identifier = UUID.randomUUID().toString();
     }
 

--- a/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/TaskReadyHandler.java
+++ b/bpm/bonita-synchro-repository/bonita-synchro-register/src/main/java/org/bonitasoft/engine/synchro/TaskReadyHandler.java
@@ -30,8 +30,8 @@ public class TaskReadyHandler extends AbstractJMSUpdateHandler {
 
     private final String identifier;
 
-    public TaskReadyHandler(final long tenantId, final long messageTimeout) {
-        super(tenantId, messageTimeout);
+    public TaskReadyHandler(final long tenantId, final long messageTimeout, final String brokerURL) {
+        super(tenantId, messageTimeout, brokerURL);
         this.identifier = UUID.randomUUID().toString();
     }
 


### PR DESCRIPTION
...with the client URL in the server System properties. Here we are adding it in the AddPerfHandlerCommand in order to simplify Bonita Performance tool usage. So broker URL is not needed in the app server of the tested Bonita.

Added to "AddPerfHandlerCommand" the "brokerURL" parameter.
Added to AbstractJMSUpdateHandler and its derived classes constructors the parameter "broker URL".
In JMS producer, broker URL is now initialized by this message instead of using a system property.
Caution : like before, only one JMS producer is used now for all tenants.