### PR TITLE
Fix Classloader issue

### DIFF
--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/ProcessAPIImpl.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/ProcessAPIImpl.java
@@ -2593,7 +2593,7 @@ public class ProcessAPIImpl implements ProcessAPI {
         final String dataClassName = sDataInstance.getClassName();
         Class<?> dataClass;
         try {
-            dataClass = Class.forName(dataClassName);
+            dataClass = Class.forName(dataClassName, true, Thread.currentThread().getContextClassLoader());
         } catch (final ClassNotFoundException e) {
             throw new UpdateException(e);
         }


### PR DESCRIPTION
Calling ProcessAPI method updateActivityDataInstance(String varName, long activityInstanceId, Object  newValue) was throwing a ClassNotFoundException if newValue was of type a java class outside the JDK (aka business class).

Class.forName was used without specifying ClassLoader and Class.forName is not aware of Thread context class loader. 