### PR TITLE
BS-13108, avoid to use unmerged business objects as operations dependenc...

### DIFF
--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/pom.xml
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/pom.xml
@@ -87,5 +87,11 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.bonitasoft.engine.expression</groupId>
+			<artifactId>bonita-expression-api-impl</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/AssignmentOperationExecutorStrategy.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/AssignmentOperationExecutorStrategy.java
@@ -18,6 +18,7 @@ import org.bonitasoft.engine.core.operation.OperationExecutorStrategy;
 import org.bonitasoft.engine.core.operation.exception.SOperationExecutionException;
 import org.bonitasoft.engine.core.operation.model.SLeftOperand;
 import org.bonitasoft.engine.core.operation.model.SOperation;
+import org.bonitasoft.engine.core.operation.model.SOperatorType;
 
 /**
  * AssignmentOperationExecutorStrategy is the default Bonita strategy to execute data assignment operations
@@ -30,19 +31,14 @@ import org.bonitasoft.engine.core.operation.model.SOperation;
 public class AssignmentOperationExecutorStrategy implements OperationExecutorStrategy {
 
     /**
-     * The Operation type of this strategy, as a String
-     */
-    public static final String TYPE_ASSIGNMENT = "ASSIGNMENT";
-
-    /**
      * Builds a new AssignmentOperationExecutorStrategy, which is the strategy to execute data assignment operations
-     *
      */
     public AssignmentOperationExecutorStrategy() {
     }
 
     @Override
-    public Object computeNewValueForLeftOperand(final SOperation operation, final Object value, final SExpressionContext expressionContext) throws SOperationExecutionException {
+    public Object computeNewValueForLeftOperand(final SOperation operation, final Object value, final SExpressionContext expressionContext,
+            final boolean shouldPersistValue) throws SOperationExecutionException {
         // do not check if value is external, see ENGINE-1739
         if (operation.getLeftOperand().getType().equals(SLeftOperand.TYPE_DATA)) {
             checkReturnType(value, operation, expressionContext);
@@ -73,6 +69,7 @@ public class AssignmentOperationExecutorStrategy implements OperationExecutorStr
 
     @Override
     public String getOperationType() {
-        return TYPE_ASSIGNMENT;
+        return SOperatorType.ASSIGNMENT.name();
     }
+
 }

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/JavaMethodOperationExecutorStrategy.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/JavaMethodOperationExecutorStrategy.java
@@ -32,7 +32,8 @@ public class JavaMethodOperationExecutorStrategy implements OperationExecutorStr
     }
 
     @Override
-    public Object computeNewValueForLeftOperand(final SOperation operation, final Object valueToSetObjectWith, final SExpressionContext expressionContext)
+    public Object computeNewValueForLeftOperand(final SOperation operation, final Object valueToSetObjectWith, final SExpressionContext expressionContext,
+            final boolean shouldPersistValue)
             throws SOperationExecutionException {
         final Object objectToInvokeJavaMethodOn;
         objectToInvokeJavaMethodOn = extractObjectToInvokeFromContext(operation, expressionContext);

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/LeftOperandIndexes.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/LeftOperandIndexes.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.core.operation.impl;
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+public class LeftOperandIndexes {
+
+    private int lastIndex = -1;
+
+    private int nextIndex = -1;
+
+    public int getLastIndex() {
+        return lastIndex;
+    }
+
+    public void setLastIndex(final int lastIndex) {
+        this.lastIndex = lastIndex;
+    }
+
+    public int getNextIndex() {
+        return nextIndex;
+    }
+
+    public void setNextIndex(final int nextIndex) {
+        this.nextIndex = nextIndex;
+    }
+}

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/LeftOperandUpdateStatus.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/LeftOperandUpdateStatus.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.core.operation.impl;
+
+import org.bonitasoft.engine.core.operation.model.SOperatorType;
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+public class LeftOperandUpdateStatus {
+
+    private boolean shouldUpdate;
+
+    public LeftOperandUpdateStatus(SOperatorType operatorType) {
+        shouldUpdate = operatorType != SOperatorType.DELETION;
+    }
+
+    public boolean shouldUpdate() {
+        return shouldUpdate;
+    }
+
+    public boolean shouldDelete() {
+        return !shouldUpdate;
+    }
+}

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/OperationServiceImpl.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/OperationServiceImpl.java
@@ -31,7 +31,6 @@ import org.bonitasoft.engine.core.operation.OperationService;
 import org.bonitasoft.engine.core.operation.exception.SOperationExecutionException;
 import org.bonitasoft.engine.core.operation.model.SLeftOperand;
 import org.bonitasoft.engine.core.operation.model.SOperation;
-import org.bonitasoft.engine.core.operation.model.SOperatorType;
 import org.bonitasoft.engine.expression.model.SExpression;
 import org.bonitasoft.engine.log.technical.TechnicalLogSeverity;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
@@ -50,16 +49,19 @@ public class OperationServiceImpl implements OperationService {
 
     private final ExpressionResolverService expressionResolverService;
 
+    private final PersistRightOperandResolver persistRightOperandResolver;
     private final TechnicalLoggerService logger;
 
     private final OperationExecutorStrategyProvider operationExecutorStrategyProvider;
 
     public OperationServiceImpl(final OperationExecutorStrategyProvider operationExecutorStrategyProvider,
             final LeftOperandHandlerProvider leftOperandHandlerProvider, final ExpressionResolverService expressionResolverService,
+            PersistRightOperandResolver persistRightOperandResolver,
             final TechnicalLoggerService logger) {
         super();
         this.operationExecutorStrategyProvider = operationExecutorStrategyProvider;
         this.expressionResolverService = expressionResolverService;
+        this.persistRightOperandResolver = persistRightOperandResolver;
         this.logger = logger;
         final List<LeftOperandHandler> leftOperandHandlers = leftOperandHandlerProvider.getLeftOperandHandlers();
         leftOperandHandlersMap = new HashMap<String, LeftOperandHandler>(leftOperandHandlers.size());
@@ -82,49 +84,61 @@ public class OperationServiceImpl implements OperationService {
     @Override
     public void execute(final List<SOperation> operations, final long leftOperandContainerId, final String leftOperandContainerType,
             final SExpressionContext expressionContext) throws SOperationExecutionException {
-        if(operations.isEmpty()) {
+        if (operations.isEmpty()) {
             return;
         }
         // retrieve all left operand to set and put it in context
         retrieveLeftOperandsAndPutItInExpressionContextIfNotIn(operations, leftOperandContainerId, leftOperandContainerType, expressionContext);
 
         // execute operation and put it in context again
-        final Map<SLeftOperand, Boolean> leftOperandUpdates = executeOperators(operations, expressionContext);
+        final Map<SLeftOperand, LeftOperandUpdateStatus> leftOperandUpdates = executeOperators(operations, expressionContext);
         // update data
         updateLeftOperands(leftOperandUpdates, leftOperandContainerId, leftOperandContainerType, expressionContext);
     }
 
-    Map<SLeftOperand, Boolean> executeOperators(final List<SOperation> operations, final SExpressionContext expressionContext)
+    Map<SLeftOperand, LeftOperandUpdateStatus> executeOperators(final List<SOperation> operations, final SExpressionContext expressionContext)
             throws SOperationExecutionException {
-        final Map<SLeftOperand, Boolean> updateLeftOperands = new HashMap<SLeftOperand, Boolean>();
-        for (final SOperation operation : operations) {
-            final SLeftOperand leftOperand = operation.getLeftOperand();
-            final SOperatorType operatorType = operation.getType();
-            final boolean update = operatorType != SOperatorType.DELETION;
-            if (update) {
-                final Object rightOperandValue = getOperationValue(operation, expressionContext, operation.getRightOperand());
-                final OperationExecutorStrategy operationExecutorStrategy = operationExecutorStrategyProvider.getOperationExecutorStrategy(operation);
-                final Object value = operationExecutorStrategy.computeNewValueForLeftOperand(operation, rightOperandValue, expressionContext);
-                expressionContext.getInputValues().put(leftOperand.getName(), value);
-                logOperation(TechnicalLogSeverity.DEBUG, operation, rightOperandValue, expressionContext);
-            }
-
-            final Boolean isAlreadyUpdated = updateLeftOperands.get(leftOperand);
-            if (isAlreadyUpdated == null || isAlreadyUpdated && !update) {
-                updateLeftOperands.put(leftOperand, update);
+        final Map<SLeftOperand, LeftOperandUpdateStatus> leftOperandsToUpdate = new HashMap<SLeftOperand, LeftOperandUpdateStatus>();
+        for (int i = 0; i < operations.size(); i++) {
+            SOperation currentOperation = operations.get(i);
+            boolean shouldPersistValue = persistRightOperandResolver.shouldPersist(i, operations);
+            LeftOperandUpdateStatus currentUpdateStatus = calculateRightOperandValue(currentOperation, expressionContext, shouldPersistValue);
+            if (shouldUpdateLeftOperandContext(leftOperandsToUpdate, currentOperation.getLeftOperand(), currentUpdateStatus)) {
+                leftOperandsToUpdate.put(currentOperation.getLeftOperand(), currentUpdateStatus);
             }
         }
-        return updateLeftOperands;
+        return leftOperandsToUpdate;
     }
 
-    void updateLeftOperands(final Map<SLeftOperand, Boolean> leftOperandUpdates, final long leftOperandContainerId, final String leftOperandContainerType,
-            final SExpressionContext expressionContext) throws SOperationExecutionException {
-        for (final Entry<SLeftOperand, Boolean> update : leftOperandUpdates.entrySet()) {
+    private LeftOperandUpdateStatus calculateRightOperandValue(final SOperation operation, final SExpressionContext expressionContext,
+            final boolean shouldPersistValue)
+            throws SOperationExecutionException {
+        final SLeftOperand leftOperand = operation.getLeftOperand();
+        LeftOperandUpdateStatus currentUpdateStatus = new LeftOperandUpdateStatus(operation.getType());
+        if (currentUpdateStatus.shouldUpdate()) {
+            final OperationExecutorStrategy operationExecutorStrategy = operationExecutorStrategyProvider.getOperationExecutorStrategy(operation);
+            final Object rightOperandValue = evaluateRightOperandExpression(operation, expressionContext, operation.getRightOperand());
+            Object value = operationExecutorStrategy.computeNewValueForLeftOperand(operation, rightOperandValue, expressionContext, shouldPersistValue);
+            expressionContext.getInputValues().put(leftOperand.getName(), value);
+            logOperation(TechnicalLogSeverity.DEBUG, operation, rightOperandValue, expressionContext);
+        }
+        return currentUpdateStatus;
+    }
+
+    boolean shouldUpdateLeftOperandContext(final Map<SLeftOperand, LeftOperandUpdateStatus> updateLeftOperands, final SLeftOperand leftOperand,
+            final LeftOperandUpdateStatus currentUpdateStatus) {
+        LeftOperandUpdateStatus previousStatus = updateLeftOperands.get(leftOperand);
+        return previousStatus == null || !previousStatus.shouldDelete() && currentUpdateStatus.shouldDelete();
+    }
+
+    void updateLeftOperands(final Map<SLeftOperand, LeftOperandUpdateStatus> leftOperandUpdates, final long leftOperandContainerId,
+            final String leftOperandContainerType, final SExpressionContext expressionContext) throws SOperationExecutionException {
+        for (final Entry<SLeftOperand, LeftOperandUpdateStatus> update : leftOperandUpdates.entrySet()) {
             final SLeftOperand leftOperand = update.getKey();
             final LeftOperandHandler leftOperandHandler = getLeftOperandHandler(leftOperand.getType());
-            if (update.getValue()) {
-                leftOperandHandler.update(leftOperand, expressionContext.getInputValues(), expressionContext.getInputValues().get(leftOperand.getName()), leftOperandContainerId,
-                        leftOperandContainerType);
+            if (update.getValue().shouldUpdate()) {
+                leftOperandHandler.update(leftOperand, expressionContext.getInputValues(), expressionContext.getInputValues().get(leftOperand.getName()),
+                        leftOperandContainerId, leftOperandContainerType);
             } else {
                 leftOperandHandler.delete(leftOperand, leftOperandContainerId, leftOperandContainerType);
             }
@@ -146,14 +160,14 @@ public class OperationServiceImpl implements OperationService {
         //if the container where we execute the operation is not the same than the container of the expression (call activity data mapping) we skip the loading of left operand
         String containerType = expressionContext.getContainerType();
         Long containerId = expressionContext.getContainerId();
-        if(containerId == null || containerId != dataContainerId || containerType == null || !containerType.equals(dataContainerType)){
+        if (containerId == null || containerId != dataContainerId || containerType == null || !containerType.equals(dataContainerType)) {
             return;
         }
         HashMap<String, List<SLeftOperand>> leftOperandHashMap = new HashMap<String, List<SLeftOperand>>();
         for (final SOperation operation : operations) {
             // this operation will set a data, we retrieve it and put it in context
             final SLeftOperand leftOperand = operation.getLeftOperand();
-            if(!leftOperandHashMap.containsKey(leftOperand.getType())){
+            if (!leftOperandHashMap.containsKey(leftOperand.getType())) {
                 leftOperandHashMap.put(leftOperand.getType(), new ArrayList<SLeftOperand>());
             }
             leftOperandHashMap.get(leftOperand.getType()).add(leftOperand);
@@ -163,13 +177,13 @@ public class OperationServiceImpl implements OperationService {
                 getLeftOperandHandler(leftOperandByType.getKey()).loadLeftOperandInContext(leftOperandByType.getValue(),
                         expressionContext, inputValues);
             } catch (final SBonitaReadException e) {
-                throw new SOperationExecutionException("Unable to retrieve value for operation "+leftOperandByType.getValue(), e);
+                throw new SOperationExecutionException("Unable to retrieve value for operation " + leftOperandByType.getValue(), e);
             }
         }
 
     }
 
-    protected Object getOperationValue(final SOperation operation, final SExpressionContext expressionContext, final SExpression sExpression)
+    protected Object evaluateRightOperandExpression(final SOperation operation, final SExpressionContext expressionContext, final SExpression sExpression)
             throws SOperationExecutionException {
         if (sExpression == null) {
             return null;

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/OperationsAnalyzer.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/OperationsAnalyzer.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ */
+
+package org.bonitasoft.engine.core.operation.impl;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.bonitasoft.engine.core.operation.model.SLeftOperand;
+import org.bonitasoft.engine.core.operation.model.SOperation;
+import org.bonitasoft.engine.expression.ExpressionType;
+import org.bonitasoft.engine.expression.model.SExpression;
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+public class OperationsAnalyzer {
+
+    /**
+     * Finds the index of operation of type {@link SLeftOperand#TYPE_BUSINESS_DATA} that references the expression of type
+     * {@link ExpressionType#TYPE_BUSINESS_DATA} with given name directly on the right operand or in transitive dependencies.
+     * 
+     * @param businessDataName the expression content
+     * @param fromIndex index of operation from which the analyse must begins
+     * @param operations list of operations @return the index of operation that references the expression with given name and type.
+     */
+    public int findBusinessDataDependencyIndex(String businessDataName, int fromIndex,
+            final List<SOperation> operations) {
+        if (fromIndex >= operations.size()) {
+            return -1;
+        }
+        for (int i = fromIndex; i < operations.size(); i++) {
+            SOperation operation = operations.get(i);
+            SExpression rightOperand = operation.getRightOperand();
+            if (matches(businessDataName, operation, rightOperand)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private boolean matches(final String businessDataName, final SOperation operation, final SExpression expression) {
+        if (expression == null) {
+            return false;
+        }
+        boolean matches = SLeftOperand.TYPE_BUSINESS_DATA.equals(operation.getLeftOperand().getType()) && businessDataName.equals(expression.getContent())
+                && ExpressionType.TYPE_BUSINESS_DATA.name().equals(expression.getExpressionType());
+        if (!matches && expression.hasDependencies()) {
+            Iterator<SExpression> iterator = expression.getDependencies().iterator();
+            while (iterator.hasNext() && !matches) {
+                matches = matches(businessDataName, operation, iterator.next());
+            }
+        }
+        return matches;
+    }
+
+    /**
+     * Calculates the next and the last indexes where the left operand located at the given index is used
+     * 
+     * @param indexOfCurrentOperation index of current operation
+     * @param operations all operations
+     * @return the next and the last indexes where the left operand located at the given index is used
+     */
+    public LeftOperandIndexes calculateIndexes(int indexOfCurrentOperation, List<SOperation> operations) {
+        LeftOperandIndexes indexes = new LeftOperandIndexes();
+        indexes.setLastIndex(indexOfCurrentOperation);
+        SOperation currentOperation = operations.get(indexOfCurrentOperation);
+
+        //start from operation that follows the current one
+        for (int i = indexOfCurrentOperation + 1; i < operations.size(); i++) {
+            SOperation operation = operations.get(i);
+            if (operation.getLeftOperand().equals(currentOperation.getLeftOperand())) {
+                indexes.setLastIndex(i);
+                if (indexes.getNextIndex() == -1) {
+                    indexes.setNextIndex(i);
+                }
+            }
+        }
+        return indexes;
+    }
+
+}

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/PersistRightOperandResolver.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/PersistRightOperandResolver.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.core.operation.impl;
+
+import java.util.List;
+
+import org.bonitasoft.engine.core.operation.model.SLeftOperand;
+import org.bonitasoft.engine.core.operation.model.SOperation;
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+public class PersistRightOperandResolver {
+
+    private OperationsAnalyzer operationsAnalyzer;
+
+    public PersistRightOperandResolver(final OperationsAnalyzer operationsAnalyzer) {
+        this.operationsAnalyzer = operationsAnalyzer;
+    }
+
+    public boolean shouldPersist(int currentIndex, List<SOperation> operations) {
+        SOperation currentOperation = operations.get(currentIndex);
+        if (!SLeftOperand.TYPE_BUSINESS_DATA.equals(currentOperation.getLeftOperand().getType())) {
+            return false;
+        }
+        LeftOperandIndexes leftOperandIndexes = operationsAnalyzer.calculateIndexes(currentIndex, operations);
+        if (currentIndex == leftOperandIndexes.getLastIndex()) {
+            return true;
+        }
+        //get the index of next operation that will use the current left operand as dependency to set another business data
+        int dependencyIndex = operationsAnalyzer.findBusinessDataDependencyIndex(currentOperation.getLeftOperand().getName(), currentIndex + 1, operations);
+        return dependencyIndex != -1 && dependencyIndex < leftOperandIndexes.getNextIndex();
+    }
+
+}

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/XpathUpdateQueryOperationExecutorStrategy.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/XpathUpdateQueryOperationExecutorStrategy.java
@@ -73,7 +73,8 @@ public class XpathUpdateQueryOperationExecutorStrategy implements OperationExecu
     }
 
     @Override
-    public Object computeNewValueForLeftOperand(final SOperation operation, final Object value, final SExpressionContext expressionContext) throws SOperationExecutionException {
+    public Object computeNewValueForLeftOperand(final SOperation operation, final Object value, final SExpressionContext expressionContext,
+            final boolean shouldPersistValue) throws SOperationExecutionException {
         try {
             final String dataInstanceName = operation.getLeftOperand().getName();
             // should be a String because the data is an xml expression
@@ -150,4 +151,5 @@ public class XpathUpdateQueryOperationExecutorStrategy implements OperationExecu
             throw new SOperationExecutionException(te);
         }
     }
+
 }

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/AssignmentOperationExecutorStrategyTest.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/AssignmentOperationExecutorStrategyTest.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 
 import org.bonitasoft.engine.core.expression.control.model.SExpressionContext;
 import org.bonitasoft.engine.core.operation.exception.SOperationExecutionException;
-import org.bonitasoft.engine.core.operation.impl.AssignmentOperationExecutorStrategy;
 import org.bonitasoft.engine.core.operation.model.SLeftOperand;
 import org.bonitasoft.engine.core.operation.model.SOperation;
 import org.bonitasoft.engine.data.instance.api.DataInstanceService;
@@ -63,7 +62,7 @@ public class AssignmentOperationExecutorStrategyTest {
     public void testGetValue() throws Exception {
         when(expressionContext.getInputValues()).thenReturn(Collections.<String, Object> singletonMap("var", "value"));
         when(leftOperand.getType()).thenReturn(SLeftOperand.TYPE_DATA);
-        Object returnedValue = assignmentOperationExecutorStrategy.computeNewValueForLeftOperand(operation, value, expressionContext);
+        Object returnedValue = assignmentOperationExecutorStrategy.computeNewValueForLeftOperand(operation, value, expressionContext, false);
         assertEquals("value", returnedValue);
     }
 
@@ -72,7 +71,7 @@ public class AssignmentOperationExecutorStrategyTest {
         // return type is not compatible
         when(expressionContext.getInputValues()).thenReturn(Collections.<String, Object> singletonMap("var", new java.util.TreeMap<String, Object>()));
         when(leftOperand.getType()).thenReturn(SLeftOperand.TYPE_EXTERNAL_DATA);
-        Object returnedValue = assignmentOperationExecutorStrategy.computeNewValueForLeftOperand(operation, value, expressionContext);
+        Object returnedValue = assignmentOperationExecutorStrategy.computeNewValueForLeftOperand(operation, value, expressionContext, false);
         assertEquals("value", returnedValue);
     }
 
@@ -81,7 +80,7 @@ public class AssignmentOperationExecutorStrategyTest {
         // return type is not compatible
         when(expressionContext.getInputValues()).thenReturn(Collections.<String, Object> singletonMap("var", new java.util.TreeMap<String, Object>()));
         when(leftOperand.getType()).thenReturn(SLeftOperand.TYPE_DATA);
-        assignmentOperationExecutorStrategy.computeNewValueForLeftOperand(operation, value, expressionContext);
+        assignmentOperationExecutorStrategy.computeNewValueForLeftOperand(operation, value, expressionContext, false);
     }
 
 }

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/JavaMethodOperationExecutorStrategyTest.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/JavaMethodOperationExecutorStrategyTest.java
@@ -54,7 +54,7 @@ public class JavaMethodOperationExecutorStrategyTest {
 
         final SExpressionContext expressionContext = new SExpressionContext(123L, DataInstanceContainer.PROCESS_INSTANCE.name(), 1234L);
         expressionContext.setInputValues(Collections.<String, Object> emptyMap());
-        strategy.computeNewValueForLeftOperand(operation, "Update", expressionContext);
+        strategy.computeNewValueForLeftOperand(operation, "Update", expressionContext, false);
     }
 
     @Test(expected = SOperationExecutionException.class)
@@ -76,7 +76,7 @@ public class JavaMethodOperationExecutorStrategyTest {
         map.put("myData", new MyClassThatThrowException());
         expressionContext.setInputValues(map);
 
-        strategy.computeNewValueForLeftOperand(operation, "Update", expressionContext);
+        strategy.computeNewValueForLeftOperand(operation, "Update", expressionContext, false);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class JavaMethodOperationExecutorStrategyTest {
         final Map<String, Object> map = new HashMap<String, Object>();
         map.put("myData", new MyClass());
         expressionContext.setInputValues(map);
-        final MyClass updated = (MyClass) strategy.computeNewValueForLeftOperand(operation, 12, expressionContext);
+        final MyClass updated = (MyClass) strategy.computeNewValueForLeftOperand(operation, 12, expressionContext, false);
 
         assertEquals(12, updated.getThing());
     }

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/LeftOperandIndexesTest.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/LeftOperandIndexesTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.core.operation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class LeftOperandIndexesTest {
+
+    @Test
+    public void default_constructor_should_create_index_with_negative_values() throws Exception {
+        //when
+        LeftOperandIndexes indexes = new LeftOperandIndexes();
+
+        //then
+        assertThat(indexes.getLastIndex()).isEqualTo(-1);
+        assertThat(indexes.getNextIndex()).isEqualTo(-1);
+    }
+
+    @Test
+    public void setLastIndex_should_modify_lastIndex() throws Exception {
+        //given
+        LeftOperandIndexes indexes = new LeftOperandIndexes();
+
+        //when
+        indexes.setLastIndex(4);
+
+        //then
+        assertThat(indexes.getLastIndex()).isEqualTo(4);
+        assertThat(indexes.getNextIndex()).isEqualTo(-1);
+
+    }
+
+    @Test
+    public void setNextIndex_should_modify_nextIndex() throws Exception {
+        //given
+        LeftOperandIndexes indexes = new LeftOperandIndexes();
+
+        //when
+        indexes.setNextIndex(4);
+
+        //then
+        assertThat(indexes.getLastIndex()).isEqualTo(-1);
+        assertThat(indexes.getNextIndex()).isEqualTo(4);
+
+    }
+
+}

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/LeftOperandUpdateStatusTest.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/LeftOperandUpdateStatusTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.core.operation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.bonitasoft.engine.core.operation.model.SOperatorType;
+import org.junit.Test;
+
+public class LeftOperandUpdateStatusTest {
+
+    @Test
+    public void shouldUpdate_on_assignment() throws Exception {
+        //given
+        LeftOperandUpdateStatus updateStatus = new LeftOperandUpdateStatus(SOperatorType.ASSIGNMENT);
+
+        //then
+        assertThat(updateStatus.shouldUpdate()).isTrue();
+        assertThat(updateStatus.shouldDelete()).isFalse();
+    }
+
+    @Test
+    public void shouldUpdate_on_java_method() throws Exception {
+        //given
+        LeftOperandUpdateStatus updateStatus = new LeftOperandUpdateStatus(SOperatorType.JAVA_METHOD);
+
+        //then
+        assertThat(updateStatus.shouldUpdate()).isTrue();
+        assertThat(updateStatus.shouldDelete()).isFalse();
+    }
+
+    @Test
+    public void shouldUpdate_on_XPath() throws Exception {
+        //given
+        LeftOperandUpdateStatus updateStatus = new LeftOperandUpdateStatus(SOperatorType.XPATH_UPDATE_QUERY);
+
+        //then
+        assertThat(updateStatus.shouldUpdate()).isTrue();
+        assertThat(updateStatus.shouldDelete()).isFalse();
+    }
+
+    @Test
+    public void shouldDelete_on_deletion() throws Exception {
+        //given
+        LeftOperandUpdateStatus updateStatus = new LeftOperandUpdateStatus(SOperatorType.DELETION);
+
+        //then
+        assertThat(updateStatus.shouldUpdate()).isFalse();
+        assertThat(updateStatus.shouldDelete()).isTrue();
+    }
+
+}

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/OperationMockBuilder.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/OperationMockBuilder.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.core.operation.impl;
+
+import java.util.List;
+
+import org.bonitasoft.engine.core.operation.model.impl.SLeftOperandImpl;
+import org.bonitasoft.engine.core.operation.model.impl.SOperationImpl;
+import org.bonitasoft.engine.expression.ExpressionType;
+import org.bonitasoft.engine.expression.model.SExpression;
+import org.bonitasoft.engine.expression.model.impl.SExpressionImpl;
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+public class OperationMockBuilder {
+
+    public static SExpressionImpl buildExpression(final String content, final ExpressionType type, final List<SExpression> dependencies) {
+        return new SExpressionImpl(content, content, type.name(), "", null, dependencies);
+    }
+
+    public static SOperationImpl buildMockOperation(final String leftOperandType, final SExpressionImpl rightOperand) {
+        SOperationImpl operation = buildMockOperation(leftOperandType);
+        operation.setRightOperand(rightOperand);
+        return operation;
+    }
+
+    public static SOperationImpl buildMockOperation(final String leftOperandType) {
+        SOperationImpl operation = new SOperationImpl();
+        SLeftOperandImpl leftOperand = buildMockLeftOperand(leftOperandType);
+        operation.setLeftOperand(leftOperand);
+        return operation;
+    }
+
+    public static SLeftOperandImpl buildMockLeftOperand(final String leftOperandType) {
+        SLeftOperandImpl leftOperand = new SLeftOperandImpl();
+        leftOperand.setType(leftOperandType);
+        return leftOperand;
+    }
+
+    public static SOperationImpl buildMockOperation(final String leftOperandType, String leftOperandName) {
+        SLeftOperandImpl leftOperand = buildMockLeftOperand(leftOperandType, leftOperandName);
+        return buildMockOperation(leftOperand);
+    }
+
+    public static SOperationImpl buildMockOperation(final SLeftOperandImpl leftOperand) {
+        SOperationImpl operation = new SOperationImpl();
+        operation.setLeftOperand(leftOperand);
+        return operation;
+    }
+
+    public static SLeftOperandImpl buildMockLeftOperand(final String leftOperandType, final String leftOperandName) {
+        SLeftOperandImpl leftOperand = buildMockLeftOperand(leftOperandType);
+        leftOperand.setName(leftOperandName);
+        return leftOperand;
+    }
+
+}

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/OperationServiceImplTest.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/OperationServiceImplTest.java
@@ -1,5 +1,18 @@
 package org.bonitasoft.engine.core.operation.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -7,7 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.assertj.core.data.MapEntry;
 import org.bonitasoft.engine.core.expression.control.api.ExpressionResolverService;
 import org.bonitasoft.engine.core.expression.control.model.SExpressionContext;
 import org.bonitasoft.engine.core.operation.LeftOperandHandler;
@@ -20,31 +32,18 @@ import org.bonitasoft.engine.core.operation.model.SOperation;
 import org.bonitasoft.engine.core.operation.model.SOperatorType;
 import org.bonitasoft.engine.core.operation.model.impl.SLeftOperandImpl;
 import org.bonitasoft.engine.core.operation.model.impl.SOperationImpl;
+import org.bonitasoft.engine.expression.model.SExpression;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
 import org.bonitasoft.engine.persistence.SBonitaReadException;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyMapOf;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class OperationServiceImplTest {
@@ -53,6 +52,9 @@ public class OperationServiceImplTest {
     public static final String TYPE_2 = "type2";
     public static final String TYPE_3 = "type3";
     public static final String TYPE_4 = "type4";
+
+    public static final long LEFT_OPERAND_CONTAINER_ID = 500L;
+    public static final String LEFT_OPERAND_CONTAINER_TYPE = "process";
 
     private final class MatchLeftOperandName extends BaseMatcher<SLeftOperand> {
 
@@ -115,19 +117,21 @@ public class OperationServiceImplTest {
     private OperationExecutorStrategyProvider operationExecutorStrategyProvider;
 
     @Mock
-    private OperationExecutorStrategy operationExecutorStrategy1;
+    private OperationExecutorStrategy assignmentOperationExecutorStrategy;
 
     @Mock
-    private OperationExecutorStrategy operationExecutorStrategy2;
+    private OperationExecutorStrategy xPathOperationExecutorStrategy;
 
     @Mock
-    private OperationExecutorStrategy operationExecutorStrategy3;
+    private OperationExecutorStrategy javaMethodOperationExecutorStrategy;
+
+    @Mock
+    private PersistRightOperandResolver persistRightOperandResolver;
 
     @Captor
     private ArgumentCaptor<List<SLeftOperand>> leftOperandCaptor1;
     @Captor
     private ArgumentCaptor<List<SLeftOperand>> leftOperandCaptor2;
-
 
     private OperationServiceImpl operationServiceImpl;
 
@@ -138,11 +142,17 @@ public class OperationServiceImplTest {
         return leftOperand;
     }
 
-    private SOperation buildOperation(final String type, final String dataName, final SOperatorType operatorType) {
+    private SOperationImpl buildOperation(final String type, final String dataName, final SOperatorType operatorType) {
         final SOperationImpl sOperationImpl = new SOperationImpl();
         sOperationImpl.setLeftOperand(buildLeftOperand(type, dataName));
         sOperationImpl.setType(operatorType);
         return sOperationImpl;
+    }
+
+    private SOperationImpl buildOperation(final String type, final String dataName, final SOperatorType operatorType, SExpression rightOperand) {
+        SOperationImpl operation = buildOperation(type, dataName, operatorType);
+        operation.setRightOperand(rightOperand);
+        return operation;
     }
 
     @Before
@@ -151,18 +161,19 @@ public class OperationServiceImplTest {
         doReturn(TYPE_2).when(leftOperandHandler2).getType();
         doReturn(TYPE_3).when(leftOperandHandler3).getType();
         doReturn(TYPE_4).when(leftOperandHandler4).getType();
-        doReturn(SOperatorType.ASSIGNMENT.name()).when(operationExecutorStrategy1).getOperationType();
-        doReturn(SOperatorType.XPATH_UPDATE_QUERY.name()).when(operationExecutorStrategy2).getOperationType();
-        doReturn(SOperatorType.JAVA_METHOD.name()).when(operationExecutorStrategy2).getOperationType();
-        doReturn(operationExecutorStrategy1).when(operationExecutorStrategyProvider).getOperationExecutorStrategy(
+        doReturn(SOperatorType.ASSIGNMENT.name()).when(assignmentOperationExecutorStrategy).getOperationType();
+        doReturn(SOperatorType.XPATH_UPDATE_QUERY.name()).when(xPathOperationExecutorStrategy).getOperationType();
+        doReturn(SOperatorType.JAVA_METHOD.name()).when(javaMethodOperationExecutorStrategy).getOperationType();
+        doReturn(assignmentOperationExecutorStrategy).when(operationExecutorStrategyProvider).getOperationExecutorStrategy(
                 argThat(new MatchOperationType(SOperatorType.ASSIGNMENT)));
-        doReturn(operationExecutorStrategy2).when(operationExecutorStrategyProvider).getOperationExecutorStrategy(
+        doReturn(xPathOperationExecutorStrategy).when(operationExecutorStrategyProvider).getOperationExecutorStrategy(
                 argThat(new MatchOperationType(SOperatorType.XPATH_UPDATE_QUERY)));
-        doReturn(operationExecutorStrategy3).when(operationExecutorStrategyProvider).getOperationExecutorStrategy(
+        doReturn(javaMethodOperationExecutorStrategy).when(operationExecutorStrategyProvider).getOperationExecutorStrategy(
                 argThat(new MatchOperationType(SOperatorType.JAVA_METHOD)));
         doReturn(Arrays.asList(leftOperandHandler1, leftOperandHandler2, leftOperandHandler3, leftOperandHandler4)).when(leftOperandHandlerProvider)
                 .getLeftOperandHandlers();
-        operationServiceImpl = new OperationServiceImpl(operationExecutorStrategyProvider, leftOperandHandlerProvider, expressionResolverService, logger);
+        operationServiceImpl = new OperationServiceImpl(operationExecutorStrategyProvider, leftOperandHandlerProvider, expressionResolverService,
+                persistRightOperandResolver, logger);
     }
 
     @Test
@@ -172,66 +183,78 @@ public class OperationServiceImplTest {
         inputValues.put("data1", "value1");
         inputValues.put("data2", "value2");
         final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", inputValues);
-        final Map<SLeftOperand, Boolean> updates = new HashMap<SLeftOperand, Boolean>();
-        updates.put(buildLeftOperand(TYPE_1, "data1"), true);
-        updates.put(buildLeftOperand(TYPE_2, "data2"), false);
+        final Map<SLeftOperand, LeftOperandUpdateStatus> updates = new HashMap<SLeftOperand, LeftOperandUpdateStatus>();
+        updates.put(buildLeftOperand(TYPE_1, "data1"), new LeftOperandUpdateStatus(SOperatorType.ASSIGNMENT));
+        updates.put(buildLeftOperand(TYPE_2, "data2"), new LeftOperandUpdateStatus(SOperatorType.DELETION));
 
         // when
         operationServiceImpl.updateLeftOperands(updates, 123, "containerType", expressionContext);
 
         // then
-        verify(leftOperandHandler1).update(argThat(new MatchLeftOperandName("data1")), anyMapOf(String.class, Object.class), eq("value1"), eq(123l), eq("containerType"));
+        verify(leftOperandHandler1).update(argThat(new MatchLeftOperandName("data1")), anyMapOf(String.class, Object.class), eq("value1"), eq(123l),
+                eq("containerType"));
         verify(leftOperandHandler2).delete(argThat(new MatchLeftOperandName("data2")), eq(123l), eq("containerType"));
     }
 
     @Test
-    public void should_executeOperator_call_OperationStrategies() throws Exception {
+    public void executeOperator_should_call_OperationStrategies() throws Exception {
         // given
-        final SOperation op1 = buildOperation(TYPE_1, "data1", SOperatorType.ASSIGNMENT);
-        final SOperation op2 = buildOperation(TYPE_2, "data2", SOperatorType.XPATH_UPDATE_QUERY);
+        final SOperation op1 = buildOperation(TYPE_1, "data1", SOperatorType.ASSIGNMENT, mock(SExpression.class));
+        final SOperation op2 = buildOperation(TYPE_2, "data2", SOperatorType.XPATH_UPDATE_QUERY, mock(SExpression.class));
+        final SOperation op3 = buildOperation(TYPE_2, "data2", SOperatorType.JAVA_METHOD, mock(SExpression.class));
         final Map<String, Object> inputValues = new HashMap<String, Object>();
         final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", inputValues);
-        doReturn("value1").when(operationExecutorStrategy1).computeNewValueForLeftOperand(op1, null, expressionContext);
-        doReturn("value2").when(operationExecutorStrategy2).computeNewValueForLeftOperand(op2, null, expressionContext);
+
+        List<SOperation> operations = Arrays.asList(op1, op2, op3);
+        given(persistRightOperandResolver.shouldPersist(0, operations)).willReturn(true);
+        given(persistRightOperandResolver.shouldPersist(1, operations)).willReturn(false);
+        given(persistRightOperandResolver.shouldPersist(2, operations)).willReturn(true);
+
+        doReturn("value1").when(assignmentOperationExecutorStrategy).computeNewValueForLeftOperand(op1, null, expressionContext, true);
+        doReturn("value2").when(xPathOperationExecutorStrategy).computeNewValueForLeftOperand(op2, null, expressionContext, false);
+        doReturn("value3").when(javaMethodOperationExecutorStrategy).computeNewValueForLeftOperand(op3, null, expressionContext, true);
 
         // when
-        operationServiceImpl.executeOperators(Arrays.asList(op1, op2), expressionContext);
+        operationServiceImpl.executeOperators(operations, expressionContext);
 
         // then
         assertThat(expressionContext.getInputValues().get("data1")).isEqualTo("value1");
-        assertThat(expressionContext.getInputValues().get("data2")).isEqualTo("value2");
+        assertThat(expressionContext.getInputValues().get("data2")).isEqualTo("value3");
     }
 
     @Test
     public void should_retrieveLeftOperandsAndPutItInExpressionContextIfNotIn_do_not_override_value_in_map() throws Exception {
         // given
         final SOperation op1 = buildOperation(TYPE_2, "data1", SOperatorType.XPATH_UPDATE_QUERY);
-        final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", Collections.<String, Object>singletonMap("data1",
+        final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", Collections.<String, Object> singletonMap("data1",
                 "originalValue"));
 
         // when
         operationServiceImpl.retrieveLeftOperandsAndPutItInExpressionContextIfNotIn(Arrays.asList(op1), 123, "containerType", expressionContext);
 
         // then
-        verify(leftOperandHandler2, times(1)).loadLeftOperandInContext(eq(Arrays.asList(op1.getLeftOperand())), any(SExpressionContext.class), anyMapOf(String.class, Object.class));
+        verify(leftOperandHandler2, times(1)).loadLeftOperandInContext(eq(Arrays.asList(op1.getLeftOperand())), any(SExpressionContext.class),
+                anyMapOf(String.class, Object.class));
         assertThat(expressionContext.getInputValues().get("data1")).isEqualTo("originalValue");
     }
 
     @Test
     public void executeOperatorsShouldReturnASingleUpdateForTheSameDataOfTheSameOperator() throws Exception {
         // given
-        final List<SOperation> operations = new ArrayList<SOperation>();
-        operations.add(buildOperation(TYPE_1, "data1", SOperatorType.JAVA_METHOD));
-        operations.add(buildOperation(TYPE_1, "data1", SOperatorType.JAVA_METHOD));
-        final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", Collections.<String, Object>singletonMap("data1",
+        SOperation operation1 = buildOperation(TYPE_1, "data1", SOperatorType.JAVA_METHOD);
+        SOperation operation2 = buildOperation(TYPE_1, "data1", SOperatorType.JAVA_METHOD);
+        final List<SOperation> operations = Arrays.asList(operation1, operation2);
+        final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", Collections.<String, Object> singletonMap("data1",
                 "givenValue"));
-        final OperationServiceImpl spy = spy(operationServiceImpl);
 
         // when
-        final Map<SLeftOperand, Boolean> updates = spy.executeOperators(operations, expressionContext);
+        final Map<SLeftOperand, LeftOperandUpdateStatus> updates = operationServiceImpl.executeOperators(operations, expressionContext);
 
         // then
-        assertThat(updates).hasSize(1).containsExactly(MapEntry.entry(buildLeftOperand("type1", "data1"), true));
+        assertThat(updates).hasSize(1);
+        SLeftOperandImpl leftOperand = buildLeftOperand("type1", "data1");
+        assertThat(updates.containsKey(leftOperand));
+        assertThat(updates.get(leftOperand)).isEqualToComparingFieldByField(new LeftOperandUpdateStatus(SOperatorType.JAVA_METHOD));
     }
 
     @Test
@@ -240,17 +263,22 @@ public class OperationServiceImplTest {
         final List<SOperation> operations = new ArrayList<SOperation>();
         operations.add(buildOperation(TYPE_1, "data2", SOperatorType.JAVA_METHOD));
         operations.add(buildOperation(TYPE_1, "data1", SOperatorType.JAVA_METHOD));
-        final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", Collections.<String, Object>singletonMap("data1",
+        final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", Collections.<String, Object> singletonMap("data1",
                 "givenValue"));
         final OperationServiceImpl spy = spy(operationServiceImpl);
 
         // when
-        final Map<SLeftOperand, Boolean> updates = spy.executeOperators(operations, expressionContext);
+        final Map<SLeftOperand, LeftOperandUpdateStatus> updates = spy.executeOperators(operations, expressionContext
+                );
 
         // then
-        assertThat(updates).containsOnly(MapEntry.entry(buildLeftOperand("type1", "data2"), true), MapEntry.entry(buildLeftOperand("type1", "data1"), true));
+        assertThat(updates).hasSize(2);
+        SLeftOperandImpl data2Key = buildLeftOperand("type1", "data2");
+        SLeftOperandImpl data1Key = buildLeftOperand("type1", "data1");
+        assertThat(updates).containsKeys(data2Key, data1Key);
+        assertThat(updates.get(data1Key)).isEqualToComparingFieldByField(new LeftOperandUpdateStatus(SOperatorType.JAVA_METHOD));
+        assertThat(updates.get(data2Key)).isEqualToComparingFieldByField(new LeftOperandUpdateStatus(SOperatorType.JAVA_METHOD));
     }
-
 
     @Test
     public void executeOperationShouldDoBatchGet() throws SOperationExecutionException, SBonitaReadException {
@@ -265,19 +293,16 @@ public class OperationServiceImplTest {
         final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", inputValues);
 
         //when
-        operationServiceImpl.retrieveLeftOperandsAndPutItInExpressionContextIfNotIn(operations, 123l/*data container*/, "containerType", expressionContext);
+        operationServiceImpl.retrieveLeftOperandsAndPutItInExpressionContextIfNotIn(operations, 123l/* data container */, "containerType", expressionContext);
 
         //then
-        verify(leftOperandHandler1,times(1)).loadLeftOperandInContext(leftOperandCaptor1.capture(), eq(expressionContext), eq(inputValues));
-        verify(leftOperandHandler2,times(1)).loadLeftOperandInContext(leftOperandCaptor2.capture(), eq(expressionContext), eq(inputValues));
+        verify(leftOperandHandler1, times(1)).loadLeftOperandInContext(leftOperandCaptor1.capture(), eq(expressionContext), eq(inputValues));
+        verify(leftOperandHandler2, times(1)).loadLeftOperandInContext(leftOperandCaptor2.capture(), eq(expressionContext), eq(inputValues));
         List<SLeftOperand> value1 = leftOperandCaptor1.getValue();
         List<SLeftOperand> value2 = leftOperandCaptor2.getValue();
         assertThat(value1).containsOnly(operations.get(0).getLeftOperand(), operations.get(1).getLeftOperand());
-        assertThat(value2).containsOnly(operations.get(2).getLeftOperand(),operations.get(3).getLeftOperand(), operations.get(4).getLeftOperand());
+        assertThat(value2).containsOnly(operations.get(2).getLeftOperand(), operations.get(3).getLeftOperand(), operations.get(4).getLeftOperand());
     }
-
-
-
 
     @Test
     public void executeOperationShouldNotGetWhenInAnOtherContainer() throws SOperationExecutionException, SBonitaReadException {
@@ -289,10 +314,74 @@ public class OperationServiceImplTest {
         final SExpressionContext expressionContext = new SExpressionContext(123l, "containerType", inputValues);
 
         //when
-        operationServiceImpl.retrieveLeftOperandsAndPutItInExpressionContextIfNotIn(operations, 124l/*an other data container*/, "containerType", expressionContext);
+        operationServiceImpl.retrieveLeftOperandsAndPutItInExpressionContextIfNotIn(operations, 124l/* an other data container */, "containerType",
+                expressionContext);
 
         //then
-        verify(leftOperandHandler1,times(0)).loadLeftOperandInContext(anyListOf(SLeftOperand.class), any(SExpressionContext.class), anyMapOf(String.class,Object.class));
-        verify(leftOperandHandler1,times(0)).loadLeftOperandInContext(any(SLeftOperand.class), any(SExpressionContext.class), anyMapOf(String.class,Object.class));
+        verify(leftOperandHandler1, times(0)).loadLeftOperandInContext(anyListOf(SLeftOperand.class), any(SExpressionContext.class),
+                anyMapOf(String.class, Object.class));
+        verify(leftOperandHandler1, times(0)).loadLeftOperandInContext(any(SLeftOperand.class), any(SExpressionContext.class),
+                anyMapOf(String.class, Object.class));
     }
+
+    @Test
+    public void should_not_update_left_operand_context_when_new_update() throws Exception {
+        //given
+        Map<SLeftOperand, LeftOperandUpdateStatus> leftOperands = Collections.<SLeftOperand, LeftOperandUpdateStatus> singletonMap(
+                buildLeftOperand("type1", "data1"), new LeftOperandUpdateStatus(SOperatorType.ASSIGNMENT));
+
+        //when
+        boolean shouldUpdateLeftOperandContext = operationServiceImpl.shouldUpdateLeftOperandContext(leftOperands, buildLeftOperand("type1", "data1"),
+                new LeftOperandUpdateStatus(
+                        SOperatorType.JAVA_METHOD));
+
+        //then
+        assertThat(shouldUpdateLeftOperandContext).isFalse();
+    }
+
+    @Test
+    public void should_not_update_left_operand_context_when_previous_was_a_deletion() throws Exception {
+        //given
+        Map<SLeftOperand, LeftOperandUpdateStatus> leftOperands = Collections.<SLeftOperand, LeftOperandUpdateStatus> singletonMap(
+                buildLeftOperand("type1", "data1"), new LeftOperandUpdateStatus(SOperatorType.DELETION));
+
+        //when
+        boolean shouldUpdateLeftOperandContext = operationServiceImpl.shouldUpdateLeftOperandContext(leftOperands, buildLeftOperand("type1", "data1"),
+                new LeftOperandUpdateStatus(
+                        SOperatorType.JAVA_METHOD));
+
+        //then
+        assertThat(shouldUpdateLeftOperandContext).isFalse();
+    }
+
+    @Test
+    public void should_update_left_operand_context_when_not_in_the_context() throws Exception {
+        //given
+        Map<SLeftOperand, LeftOperandUpdateStatus> leftOperands = Collections.emptyMap();
+
+        //when
+        boolean shouldUpdateLeftOperandContext = operationServiceImpl.shouldUpdateLeftOperandContext(leftOperands, buildLeftOperand("type1", "data1"),
+                new LeftOperandUpdateStatus(
+                        SOperatorType.JAVA_METHOD));
+
+        //then
+        assertThat(shouldUpdateLeftOperandContext).isTrue();
+    }
+
+    @Test
+    public void should_update_left_operand_context_when_new_operation_is_deletion() throws Exception {
+        //given
+        LeftOperandUpdateStatus previousUpdateState = new LeftOperandUpdateStatus(SOperatorType.JAVA_METHOD);
+        Map<SLeftOperand, LeftOperandUpdateStatus> leftOperands = Collections.<SLeftOperand, LeftOperandUpdateStatus> singletonMap(
+                buildLeftOperand("type1", "data1"), previousUpdateState);
+
+        //when new java method must be persisted again
+        boolean shouldUpdateLeftOperandContext = operationServiceImpl.shouldUpdateLeftOperandContext(leftOperands, buildLeftOperand("type1", "data1"),
+                new LeftOperandUpdateStatus(
+                        SOperatorType.DELETION));
+
+        //then
+        assertThat(shouldUpdateLeftOperandContext).isTrue();
+    }
+
 }

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/OperationsAnalyzerTest.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/OperationsAnalyzerTest.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.core.operation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bonitasoft.engine.core.operation.impl.OperationMockBuilder.buildExpression;
+import static org.bonitasoft.engine.core.operation.impl.OperationMockBuilder.buildMockLeftOperand;
+import static org.bonitasoft.engine.core.operation.impl.OperationMockBuilder.buildMockOperation;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.bonitasoft.engine.core.operation.model.SLeftOperand;
+import org.bonitasoft.engine.core.operation.model.SOperation;
+import org.bonitasoft.engine.core.operation.model.impl.SLeftOperandImpl;
+import org.bonitasoft.engine.core.operation.model.impl.SOperationImpl;
+import org.bonitasoft.engine.expression.ExpressionType;
+import org.bonitasoft.engine.expression.model.SExpression;
+import org.bonitasoft.engine.expression.model.impl.SExpressionImpl;
+import org.junit.Test;
+
+public class OperationsAnalyzerTest {
+
+    private OperationsAnalyzer dependencyFinder = new OperationsAnalyzer();
+
+    @Test
+    public void findDependencyIndex_should_return_minus_one_if_index_is_out_of_list() throws Exception {
+        //when
+        int index = dependencyFinder.findBusinessDataDependencyIndex("address", 1, Collections.<SOperation> emptyList());
+
+        //then
+        assertThat(index).isEqualTo(-1);
+    }
+
+    @Test
+    public void findDependencyIndex_should_return_minus_one_if_right_operand_is_null() throws Exception {
+        //when
+        int index = dependencyFinder.findBusinessDataDependencyIndex("address", 0,
+                Arrays.<SOperation> asList(buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, (SExpressionImpl) null)));
+
+        //then
+        assertThat(index).isEqualTo(-1);
+    }
+
+    @Test
+    public void findDependencyIndex_should_return_zero_if_expression_is_dependency_of_first_operation() throws Exception {
+        //given
+        String dataName1 = "address1";
+        String dataName2 = "address2";
+        ExpressionType type = ExpressionType.TYPE_BUSINESS_DATA;
+        List<SExpression> dependencies = Collections.emptyList();
+        SExpressionImpl rightOperand1 = buildExpression(dataName1, type, dependencies);
+        SExpressionImpl rightOperand2 = buildExpression(dataName2, type, dependencies);
+        List<SOperation> operations = Arrays.<SOperation> asList(buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, rightOperand1),
+                buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, rightOperand2));
+
+        //when
+        int index = dependencyFinder.findBusinessDataDependencyIndex(dataName1, 0, operations);
+
+        //then
+        assertThat(index).isEqualTo(0);
+    }
+
+    @Test
+    public void findDependencyIndex_should_return_lastIndex_if_expression_is_dependency_of_last_operation() throws Exception {
+        //given
+        String dataName1 = "address1";
+        String dataName2 = "address2";
+        ExpressionType type = ExpressionType.TYPE_BUSINESS_DATA;
+        List<SExpression> dependencies = Collections.emptyList();
+        SExpressionImpl rightOperand1 = buildExpression(dataName1, type, dependencies);
+        SExpressionImpl rightOperand2 = buildExpression(dataName2, type, dependencies);
+        List<SOperation> operations = Arrays.<SOperation> asList(buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, rightOperand1),
+                buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, rightOperand2));
+
+        //when
+        int index = dependencyFinder.findBusinessDataDependencyIndex(dataName2, 0, operations);
+
+        //then
+        assertThat(index).isEqualTo(1);
+    }
+
+    @Test
+    public void findDependencyIndex_should_return_minus_one_if_find_expression_with_same_name_but_different_type() throws Exception {
+        //given
+        String dataName1 = "address1";
+        List<SExpression> dependencies = Collections.emptyList();
+        SExpressionImpl rightOperand1 = buildExpression(dataName1, ExpressionType.TYPE_CONDITION, dependencies);
+        List<SOperation> operations = Arrays.<SOperation> asList(buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, rightOperand1));
+
+        //when
+        int index = dependencyFinder.findBusinessDataDependencyIndex(dataName1, 0, operations);
+
+        //then
+        assertThat(index).isEqualTo(-1);
+    }
+
+    @Test
+    public void findDependencyIndex_should_return_minus_one_if_expression_is_dependency_at_a_index_before_fromIndex() throws Exception {
+        //given
+        String dataName1 = "address1";
+        String dataName2 = "address2";
+        ExpressionType type = ExpressionType.TYPE_BUSINESS_DATA;
+        List<SExpression> dependencies = Collections.emptyList();
+        SExpressionImpl rightOperand1 = buildExpression(dataName1, type, dependencies);
+        SExpressionImpl rightOperand2 = buildExpression(dataName2, type, dependencies);
+        List<SOperation> operations = Arrays.<SOperation> asList(buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, rightOperand1),
+                buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, rightOperand2));
+
+        //when
+        int index = dependencyFinder.findBusinessDataDependencyIndex(dataName1, 1, operations);
+
+        //then
+        assertThat(index).isEqualTo(-1);
+    }
+
+    @Test
+    public void findDependencyIndex_should_look_at_first_dependency_level() throws Exception {
+        //given
+        String dataName1 = "address1";
+        ExpressionType type = ExpressionType.TYPE_BUSINESS_DATA;
+        SExpressionImpl dataExpression = buildExpression(dataName1, type, Collections.<SExpression> emptyList());
+        SExpressionImpl rightOperand = buildExpression("myScript", ExpressionType.TYPE_READ_ONLY_SCRIPT,
+                Collections.<SExpression> singletonList(dataExpression));
+        List<SOperation> operations = Arrays.<SOperation> asList(buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, rightOperand));
+
+        //when
+        int index = dependencyFinder.findBusinessDataDependencyIndex(dataName1, 0, operations);
+
+        //then
+        assertThat(index).isEqualTo(0);
+    }
+
+    @Test
+    public void findDependencyIndex_should_look_at_all_dependency_levels() throws Exception {
+        //given
+        String dataName1 = "address1";
+        ExpressionType type = ExpressionType.TYPE_BUSINESS_DATA;
+        SExpressionImpl dataExpression = buildExpression(dataName1, type, Collections.<SExpression> emptyList());
+        SExpressionImpl dependencyL11 = buildExpression("dep11", type, Collections.<SExpression> emptyList());
+        SExpressionImpl dependencyL12 = buildExpression("dep12", ExpressionType.TYPE_READ_ONLY_SCRIPT, Collections.<SExpression> singletonList(dataExpression));
+        SExpressionImpl rightOperand = buildExpression("myScript", ExpressionType.TYPE_READ_ONLY_SCRIPT,
+                Arrays.<SExpression> asList(dependencyL11, dependencyL12));
+        List<SOperation> operations = Arrays.<SOperation> asList(buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, rightOperand));
+
+        //when
+        int index = dependencyFinder.findBusinessDataDependencyIndex(dataName1, 0, operations);
+
+        //then
+        assertThat(index).isEqualTo(0);
+    }
+
+    @Test
+    public void calculate_indexes_should_return_positive_values_when_left_operand_is_found() throws Exception {
+        //given
+        SLeftOperandImpl data1 = buildMockLeftOperand(SLeftOperand.TYPE_BUSINESS_DATA, "data1");
+        SOperationImpl op1 = buildMockOperation(data1);
+        SOperationImpl op2 = buildMockOperation(data1);
+        SOperationImpl op3 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "data2");
+        SOperationImpl op4 = buildMockOperation(data1);
+
+        //when
+        LeftOperandIndexes indexes = dependencyFinder.calculateIndexes(0, Arrays.<SOperation> asList(op1, op2, op3, op4));
+
+        //then
+        assertThat(indexes.getNextIndex()).isEqualTo(1);
+        assertThat(indexes.getLastIndex()).isEqualTo(3);
+    }
+
+    @Test
+    public void calculate_indexes_should_return_negative_value_for_nextIndex_when_is_last() throws Exception {
+        //given
+        SLeftOperandImpl data1 = buildMockLeftOperand(SLeftOperand.TYPE_BUSINESS_DATA, "data1");
+        SOperationImpl op1 = buildMockOperation(data1);
+        SOperationImpl op2 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "data2");
+
+        //when
+        LeftOperandIndexes indexes = dependencyFinder.calculateIndexes(1, Arrays.<SOperation> asList(op1, op2));
+
+        //then
+        assertThat(indexes.getNextIndex()).isEqualTo(-1);
+        assertThat(indexes.getLastIndex()).isEqualTo(1);
+    }
+
+}

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/PersistRightOperandResolverTest.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/test/java/org/bonitasoft/engine/core/operation/impl/PersistRightOperandResolverTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.core.operation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.bonitasoft.engine.core.operation.impl.OperationMockBuilder.buildMockOperation;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.bonitasoft.engine.core.operation.model.SLeftOperand;
+import org.bonitasoft.engine.core.operation.model.SOperation;
+import org.bonitasoft.engine.core.operation.model.impl.SOperationImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PersistRightOperandResolverTest {
+
+    @Mock
+    private OperationsAnalyzer operationsAnalyzer;
+
+    @InjectMocks
+    private PersistRightOperandResolver resolver;
+
+    @Test
+    public void should_not_persist_if_not_business_data() throws Exception {
+        //when
+        boolean persist = resolver.shouldPersist(0, Arrays.<SOperation> asList(buildMockOperation(SLeftOperand.TYPE_DATA)));
+
+        //then
+        assertThat(persist).isFalse();
+    }
+
+    @Test
+    public void should_persist_bo_if_is_last_operation_for_this_left_operand() throws Exception {
+        //given
+        SOperationImpl addressOp1 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "address");
+        SOperationImpl employeeOp1 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "employee");
+        SOperationImpl addressOp2 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "address");
+
+        List<SOperation> operations = Arrays.<SOperation> asList(addressOp1, employeeOp1, addressOp2);
+        LeftOperandIndexes indexes = new LeftOperandIndexes();
+        indexes.setLastIndex(2);
+        given(operationsAnalyzer.calculateIndexes(2, operations)).willReturn(indexes);
+
+        //when
+        boolean persist = resolver.shouldPersist(2, operations);
+
+        //then
+        assertThat(persist).isTrue();
+        verify(operationsAnalyzer, never()).findBusinessDataDependencyIndex(anyString(), anyInt(), anyListOf(SOperation.class));
+
+    }
+
+    @Test
+    public void should_persist_bo_when_next_operation_on_this_left_operand_is_after_next_usage_as_dependency() throws Exception {
+        //given
+        SOperationImpl addressOp1 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "address");
+        SOperationImpl employeeOp1 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "employee");
+        SOperationImpl addressOp2 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "address");
+        SOperationImpl employeeOp2 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "employee");
+
+        List<SOperation> operations = Arrays.<SOperation> asList(addressOp1, employeeOp1, addressOp2, employeeOp2);
+
+        int currentIndex = 0;
+        given(operationsAnalyzer.findBusinessDataDependencyIndex("address", currentIndex + 1, operations)).willReturn(1);
+        LeftOperandIndexes indexes = new LeftOperandIndexes();
+        indexes.setNextIndex(2);
+        given(operationsAnalyzer.calculateIndexes(0, operations)).willReturn(indexes);
+
+        //when
+        boolean persist = resolver.shouldPersist(currentIndex, operations);
+
+        //then
+        assertThat(persist).isTrue();
+    }
+
+    @Test
+    public void should_not_persist_bo_when_is_not_last_operation_for_this_left_operand_neither_is_dependency() throws Exception {
+        //given
+        SOperationImpl addressOp1 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "address");
+        SOperationImpl employeeOp1 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "employee");
+        SOperationImpl addressOp2 = buildMockOperation(SLeftOperand.TYPE_BUSINESS_DATA, "address");
+
+        int indexOfCurrentOperation = 0;
+        List<SOperation> operations = Arrays.<SOperation> asList(addressOp1, employeeOp1, addressOp2);
+        LeftOperandIndexes indexes = new LeftOperandIndexes();
+        indexes.setLastIndex(2);
+        indexes.setNextIndex(2);
+        given(operationsAnalyzer.calculateIndexes(indexOfCurrentOperation, operations)).willReturn(indexes);
+
+        given(operationsAnalyzer.findBusinessDataDependencyIndex("address", indexOfCurrentOperation + 1, operations)).willReturn(-1);
+
+        //when
+        boolean persist = resolver.shouldPersist(indexOfCurrentOperation, operations);
+
+        //then
+        assertThat(persist).isFalse();
+
+    }
+
+}

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api/src/main/java/org/bonitasoft/engine/core/operation/OperationExecutorStrategy.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api/src/main/java/org/bonitasoft/engine/core/operation/OperationExecutorStrategy.java
@@ -26,18 +26,18 @@ import org.bonitasoft.engine.core.operation.model.SOperation;
 public interface OperationExecutorStrategy {
 
     /**
-     * 
      * Calculate the new value of the left operand base of right operand expression value
-     * 
-     * @param operation
+     *
+     * @param operation the operation in progress
      * @param rightOperandValue
-     *            result of the evaluation of right operand expression
-     * @param expressionContext
+     *        result of the evaluation of right operand expression
+     * @param expressionContext the expression context
+     * @param shouldPersistValue true if the right operand must be persisted (Business Data)
      * @return
      *         the new value to set the left operand with
      * @throws SOperationExecutionException
      */
-    Object computeNewValueForLeftOperand(SOperation operation, Object rightOperandValue, SExpressionContext expressionContext)
+    Object computeNewValueForLeftOperand(SOperation operation, Object rightOperandValue, SExpressionContext expressionContext, final boolean shouldPersistValue)
             throws SOperationExecutionException;
 
     String getOperationType();

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api/src/main/java/org/bonitasoft/engine/core/operation/OperationExecutorStrategyProvider.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api/src/main/java/org/bonitasoft/engine/core/operation/OperationExecutorStrategyProvider.java
@@ -18,7 +18,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.bonitasoft.engine.core.operation.exception.SOperationExecutionException;
+import org.bonitasoft.engine.core.operation.model.SLeftOperand;
 import org.bonitasoft.engine.core.operation.model.SOperation;
+import org.bonitasoft.engine.core.operation.model.SOperatorType;
 
 /**
  * @author Zhang Bole
@@ -35,12 +37,21 @@ public class OperationExecutorStrategyProvider {
     }
     
     public OperationExecutorStrategy getOperationExecutorStrategy(final SOperation operation) throws SOperationExecutionException {
-        final String operatorTypeName = operation.getType().name();
+        final String operatorTypeName = getStrategyKey(operation);
         final OperationExecutorStrategy operationExecutorStrategy = operationStrategies.get(operatorTypeName);
         if (operationExecutorStrategy == null) {
             throw new SOperationExecutionException("Unable to find an executor for operation type " + operatorTypeName);
         }
         return operationExecutorStrategy;
+    }
+
+    protected String getStrategyKey(final SOperation operation) {
+        String key = operation.getType().name();
+        String leftOperandType = operation.getLeftOperand().getType();
+        if (leftOperandType.equals(SLeftOperand.TYPE_BUSINESS_DATA) && key.equals(SOperatorType.ASSIGNMENT.name())) {
+            key += "_" + leftOperandType;
+        }
+        return key;
     }
 
 }

--- a/bpm/bonita-home/base/server/platform/tenant-template/conf/services/cfg-bos-operation-api-impl.xml
+++ b/bpm/bonita-home/base/server/platform/tenant-template/conf/services/cfg-bos-operation-api-impl.xml
@@ -1,10 +1,17 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
+    <bean id="operationsAnalyzer" class="org.bonitasoft.engine.core.operation.impl.OperationsAnalyzer"/>
+
+    <bean id="persistRightOperandResolver" class="org.bonitasoft.engine.core.operation.impl.PersistRightOperandResolver">
+        <constructor-arg name="operationsAnalyzer" ref="operationsAnalyzer" />
+    </bean>
+
     <bean id="operationService" class="org.bonitasoft.engine.core.operation.impl.OperationServiceImpl">
         <constructor-arg name="operationExecutorStrategyProvider" ref="operationExecutorStrategyProvider"/>
         <constructor-arg name="leftOperandHandlerProvider" ref="leftOperandHandlerProvider"/>
         <constructor-arg name="expressionResolverService" ref="expressionResolverService"/>
+        <constructor-arg name="persistRightOperandResolver" ref="persistRightOperandResolver"/>
         <constructor-arg name="logger" ref="tenantTechnicalLoggerService"/>
     </bean>
 

--- a/services/bonita-commons/src/main/java/org/bonitasoft/engine/commons/Container.java
+++ b/services/bonita-commons/src/main/java/org/bonitasoft/engine/commons/Container.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.commons;
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+public class Container {
+
+    private long id;
+
+    private String type;
+
+    public Container(final long id, final String type) {
+        this.id = id;
+        this.type = type;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/services/bonita-commons/src/test/java/org/bonitasoft/engine/commons/ContainerTest.java
+++ b/services/bonita-commons/src/test/java/org/bonitasoft/engine/commons/ContainerTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.commons;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ContainerTest {
+
+    @Test
+    public void constructor_should_create_container_based_on_given_information() throws Exception {
+        //when
+        Container container = new Container(10, "cType");
+
+        //then
+        assertThat(container.getId()).isEqualTo(10);
+        assertThat(container.getType()).isEqualTo("cType");
+    }
+}

--- a/services/bonita-data-instance/bonita-data-instance-api/src/main/java/org/bonitasoft/engine/data/instance/api/DataInstanceContainer.java
+++ b/services/bonita-data-instance/bonita-data-instance-api/src/main/java/org/bonitasoft/engine/data/instance/api/DataInstanceContainer.java
@@ -23,6 +23,6 @@ public enum DataInstanceContainer {
 
     ACTIVITY_INSTANCE,
 
-    MESSAGE_INSTANCE;
+    MESSAGE_INSTANCE
 
 }

--- a/services/bonita-expression/bonita-expression-api-impl/src/main/java/org/bonitasoft/engine/expression/model/impl/SExpressionImpl.java
+++ b/services/bonita-expression/bonita-expression-api-impl/src/main/java/org/bonitasoft/engine/expression/model/impl/SExpressionImpl.java
@@ -111,6 +111,11 @@ public class SExpressionImpl implements SExpression {
     }
 
     @Override
+    public boolean hasDependencies() {
+        return !getDependencies().isEmpty();
+    }
+
+    @Override
     public ExpressionKind getExpressionKind() {
         return expressionKind;
     }

--- a/services/bonita-expression/bonita-expression-api/src/main/java/org/bonitasoft/engine/expression/model/SExpression.java
+++ b/services/bonita-expression/bonita-expression-api/src/main/java/org/bonitasoft/engine/expression/model/SExpression.java
@@ -61,6 +61,8 @@ public interface SExpression extends Serializable {
 
     List<SExpression> getDependencies();
 
+    boolean hasDependencies();
+
     int getDiscriminant();
 
 }


### PR DESCRIPTION
...y.

 Cause: new Business Object instances were put in the context before merge (entities without persistence Id)
 Fix:separate logic of update left operand and merge business objects. Now, business objects are merged when the current operation is the last one that uses the related business data as left operand or when another operation will use the current business data as dependency before the next operation on the current business data.