### PR TITLE
Default jobs are now updated at tenant start

### DIFF
--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/PlatformAPIImpl.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/PlatformAPIImpl.java
@@ -14,10 +14,13 @@
 package org.bonitasoft.engine.api.impl;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 
 import org.bonitasoft.engine.api.PlatformAPI;
@@ -71,8 +74,14 @@ import org.bonitasoft.engine.platform.model.STenant;
 import org.bonitasoft.engine.platform.model.builder.SPlatformBuilderFactory;
 import org.bonitasoft.engine.platform.model.builder.STenantBuilderFactory;
 import org.bonitasoft.engine.scheduler.AbstractBonitaTenantJobListener;
+import org.bonitasoft.engine.scheduler.JobRegister;
 import org.bonitasoft.engine.scheduler.SchedulerService;
+import org.bonitasoft.engine.scheduler.builder.SJobDescriptorBuilderFactory;
+import org.bonitasoft.engine.scheduler.builder.SJobParameterBuilderFactory;
 import org.bonitasoft.engine.scheduler.exception.SSchedulerException;
+import org.bonitasoft.engine.scheduler.model.SJobDescriptor;
+import org.bonitasoft.engine.scheduler.model.SJobParameter;
+import org.bonitasoft.engine.scheduler.trigger.Trigger;
 import org.bonitasoft.engine.service.ModelConvertor;
 import org.bonitasoft.engine.service.PlatformServiceAccessor;
 import org.bonitasoft.engine.service.TenantServiceAccessor;
@@ -228,6 +237,8 @@ public class PlatformAPIImpl implements PlatformAPI {
                 if (mustRestartElements) {
                     afterServicesStartOfRestartHandlersOfTenant(platformAccessor, sessionAccessor, tenants);
                 }
+                registerMissingTenantsDefaultJobs(tenants);
+
             } catch (final SClassLoaderException e) {
                 throw new StartNodeException("Platform starting failed while initializing platform classloaders.", e);
             } catch (final SDependencyException e) {
@@ -250,6 +261,69 @@ public class PlatformAPIImpl implements PlatformAPI {
             }
             throw e;
         }
+    }
+
+    /**
+     * Registers missing default jobs (if any) for the provided tenants
+     * @param tenants
+     * @throws BonitaHomeNotSetException
+     * @throws BonitaHomeConfigurationException
+     * @throws NoSuchMethodException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     * @throws SBonitaException
+     * @throws IOException
+     * @throws ClassNotFoundException 
+     */
+    protected void registerMissingTenantsDefaultJobs(final List<STenant> tenants) throws BonitaHomeNotSetException, BonitaHomeConfigurationException, NoSuchMethodException,
+            InstantiationException, IllegalAccessException, InvocationTargetException, SBonitaException, IOException, ClassNotFoundException {
+        for (final STenant tenant : tenants) {
+            SessionAccessor sessionAccessor = null;
+            long platformSessionId = -1;
+            try {
+            	final TransactionService transactionService = getPlatformAccessor().getTransactionService();
+            	final TenantServiceAccessor tenantServiceAccessor = getTenantServiceAccessor(tenant.getId());
+            	
+            	sessionAccessor = createSessionAccessor();
+            	final long sessionId = createSession(tenant.getId(), tenantServiceAccessor.getSessionService());
+            	platformSessionId = sessionAccessor.getSessionId();
+                sessionAccessor.deleteSessionId();
+                sessionAccessor.setSessionInfo(sessionId, tenant.getId());
+            	
+                final SchedulerService schedulerService = tenantServiceAccessor.getSchedulerService();
+                final TenantConfiguration tenantConfiguration = tenantServiceAccessor.getTenantConfiguration();
+                final List<JobRegister> defaultJobs = tenantConfiguration.getJobsToRegister();
+                final List<String> scheduledJobNames = schedulerService.getJobs();
+                
+                // Only register missing default jobs if they are missing
+                transactionService.begin();
+                try {
+                	for (final JobRegister defaultJob : defaultJobs) {
+                        if (!scheduledJobNames.contains(defaultJob.getJobName())) {
+                            registerJob(schedulerService, defaultJob);
+                        }
+                    }
+                }
+                finally {
+                    transactionService.complete();
+                }
+            }
+            finally {
+            	cleanSessionAccessor(sessionAccessor, platformSessionId);
+            }
+        }
+    }
+
+    protected void registerJob(final SchedulerService schedulerService, final JobRegister jobRegister) throws SSchedulerException {
+        final SJobDescriptor jobDescriptor = BuilderFactory.get(SJobDescriptorBuilderFactory.class)
+                .createNewInstance(jobRegister.getJobClass().getName(), jobRegister.getJobName(), true).done();
+        final List<SJobParameter> jobParameters = new ArrayList<SJobParameter>();
+        for (final Entry<String, Serializable> entry : jobRegister.getJobParameters().entrySet()) {
+            jobParameters.add(BuilderFactory.get(SJobParameterBuilderFactory.class).createNewInstance(entry.getKey(), entry.getValue()).done());
+        }
+        final Trigger trigger = jobRegister.getTrigger();
+        schedulerService.schedule(jobDescriptor, jobParameters, trigger);
     }
 
     SessionAccessor createSessionAccessor() throws BonitaHomeNotSetException, InstantiationException, IllegalAccessException, ClassNotFoundException,

--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/transaction/platform/ActivateTenant.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/transaction/platform/ActivateTenant.java
@@ -13,11 +13,8 @@
  **/
 package org.bonitasoft.engine.api.impl.transaction.platform;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
-import java.util.Map.Entry;
 import java.util.UUID;
 
 import org.bonitasoft.engine.api.impl.NodeConfiguration;
@@ -31,10 +28,8 @@ import org.bonitasoft.engine.jobs.CleanInvalidSessionsJob;
 import org.bonitasoft.engine.log.technical.TechnicalLogSeverity;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
 import org.bonitasoft.engine.platform.PlatformService;
-import org.bonitasoft.engine.scheduler.JobRegister;
 import org.bonitasoft.engine.scheduler.SchedulerService;
 import org.bonitasoft.engine.scheduler.builder.SJobDescriptorBuilderFactory;
-import org.bonitasoft.engine.scheduler.builder.SJobParameterBuilderFactory;
 import org.bonitasoft.engine.scheduler.exception.SSchedulerException;
 import org.bonitasoft.engine.scheduler.model.SJobDescriptor;
 import org.bonitasoft.engine.scheduler.model.SJobParameter;
@@ -92,37 +87,6 @@ public final class ActivateTenant implements TransactionContent {
             connectorExecutor.start();
             startEventHandling();
             startCleanInvalidSessionsJob();
-            final List<JobRegister> jobsToRegister = tenantConfiguration.getJobsToRegister();
-            for (final JobRegister jobRegister : jobsToRegister) {
-                registerJob(jobRegister);
-            }
-        }
-    }
-
-    private void registerJob(final JobRegister jobRegister) {
-        try {
-            final List<String> jobs = schedulerService.getAllJobs();
-            if (!jobs.contains(jobRegister.getJobName())) {
-                if (logger.isLoggable(this.getClass(), TechnicalLogSeverity.INFO)) {
-                    logger.log(this.getClass(), TechnicalLogSeverity.INFO, "Register " + jobRegister.getJobDescription());
-                }
-                final SJobDescriptor jobDescriptor = BuilderFactory.get(SJobDescriptorBuilderFactory.class)
-                        .createNewInstance(jobRegister.getJobClass().getName(), jobRegister.getJobName(), true).done();
-                final ArrayList<SJobParameter> jobParameters = new ArrayList<SJobParameter>();
-                for (final Entry<String, Serializable> entry : jobRegister.getJobParameters().entrySet()) {
-                    jobParameters.add(BuilderFactory.get(SJobParameterBuilderFactory.class).createNewInstance(entry.getKey(), entry.getValue()).done());
-                }
-                final Trigger trigger = jobRegister.getTrigger();
-                schedulerService.schedule(jobDescriptor, jobParameters, trigger);
-            } else {
-                logger.log(this.getClass(), TechnicalLogSeverity.INFO, "The " + jobRegister.getJobDescription() + " was already started");
-            }
-        } catch (final SSchedulerException e) {
-            logger.log(this.getClass(), TechnicalLogSeverity.ERROR,
-                    "Unable to register job " + jobRegister.getJobDescription() + " because " + e.getMessage());
-            if (logger.isLoggable(this.getClass(), TechnicalLogSeverity.DEBUG)) {
-                logger.log(this.getClass(), TechnicalLogSeverity.DEBUG, e);
-            }
         }
     }
 

--- a/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/PlatformAPIImplTest.java
+++ b/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/PlatformAPIImplTest.java
@@ -24,18 +24,24 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 
+import org.bonitasoft.engine.commons.exceptions.SBonitaException;
+import org.bonitasoft.engine.exception.BonitaHomeConfigurationException;
+import org.bonitasoft.engine.exception.BonitaHomeNotSetException;
 import org.bonitasoft.engine.exception.UpdateException;
 import org.bonitasoft.engine.platform.model.STenant;
 import org.bonitasoft.engine.scheduler.AbstractBonitaPlatformJobListener;
 import org.bonitasoft.engine.scheduler.AbstractBonitaTenantJobListener;
+import org.bonitasoft.engine.scheduler.JobRegister;
 import org.bonitasoft.engine.scheduler.SchedulerService;
 import org.bonitasoft.engine.scheduler.exception.SSchedulerException;
 import org.bonitasoft.engine.service.PlatformServiceAccessor;
 import org.bonitasoft.engine.service.TenantServiceAccessor;
 import org.bonitasoft.engine.sessionaccessor.SessionAccessor;
+import org.bonitasoft.engine.transaction.TransactionService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -173,5 +179,71 @@ public class PlatformAPIImplTest {
         // Then
         verify(schedulerService).initializeScheduler();
         verify(schedulerService, never()).addJobListener(anyListOf(AbstractBonitaPlatformJobListener.class));
+    }
+
+    @Test
+    public void startNode_should_call_registerMissingTenantsDefaultJobs() throws Exception {
+        // Given
+        doNothing().when(platformAPI).checkPlatformVersion(platformServiceAccessor);
+        doNothing().when(platformAPI).startPlatformServices(platformServiceAccessor);
+        final List<STenant> tenants = Collections.singletonList(mock(STenant.class));
+        doReturn(true).when(platformAPI).isNodeStarted();
+        doNothing().when(platformAPI).registerMissingTenantsDefaultJobs(tenants);
+
+        // When
+        platformAPI.startNode();
+
+        // Then
+        verify(platformAPI).registerMissingTenantsDefaultJobs(tenants);
+    }
+
+    @Test
+    public void registerMissingTenantsDefaultJobs_should_call_registerJob_when_job_is_missing() throws BonitaHomeNotSetException,
+            BonitaHomeConfigurationException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException,
+            SBonitaException, IOException, ClassNotFoundException {
+        // Given
+    	final TransactionService transactionService = mock(TransactionService.class);
+    	doReturn(transactionService).when(platformServiceAccessor).getTransactionService();
+    	doNothing().when(transactionService).begin();
+    	doNothing().when(transactionService).complete();
+    	final List<STenant> tenants = Collections.singletonList(mock(STenant.class));
+        final JobRegister jobRegister = mock(JobRegister.class);
+        doReturn("newJob").when(jobRegister).getJobName();
+        final List<JobRegister> defaultJobs = Collections.singletonList(jobRegister);
+        doReturn(defaultJobs).when(tenantConfiguration).getJobsToRegister();
+        final List<String> scheduledJobNames = Collections.singletonList("someOtherJob");
+        doReturn(scheduledJobNames).when(schedulerService).getJobs();
+        doNothing().when(platformAPI).registerJob(schedulerService, jobRegister);
+
+        // When
+        platformAPI.registerMissingTenantsDefaultJobs(tenants);
+
+        // Then
+        verify(platformAPI).registerJob(schedulerService, jobRegister);
+    }
+
+    @Test
+    public void registerMissingTenantsDefaultJobs_should_not_call_registerJob_when_job_is_scheduled() throws BonitaHomeNotSetException,
+            BonitaHomeConfigurationException, NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException,
+            SBonitaException, IOException, ClassNotFoundException {
+        // Given
+    	final TransactionService transactionService = mock(TransactionService.class);
+    	doReturn(transactionService).when(platformServiceAccessor).getTransactionService();
+    	doNothing().when(transactionService).begin();
+    	doNothing().when(transactionService).complete();
+    	final List<STenant> tenants = Collections.singletonList(mock(STenant.class));
+        final JobRegister jobRegister = mock(JobRegister.class);
+        doReturn("existingJob").when(jobRegister).getJobName();
+        final List<JobRegister> defaultJobs = Collections.singletonList(jobRegister);
+        doReturn(defaultJobs).when(tenantConfiguration).getJobsToRegister();
+        final List<String> scheduledJobNames = Collections.singletonList("existingJob");
+        doReturn(scheduledJobNames).when(schedulerService).getJobs();
+        doNothing().when(platformAPI).registerJob(schedulerService, jobRegister);
+
+        // When
+        platformAPI.registerMissingTenantsDefaultJobs(tenants);
+
+        // Then
+        verify(platformAPI, never()).registerJob(schedulerService, jobRegister);
     }
 }

--- a/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/transaction/platform/ActivateTenantTest.java
+++ b/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/transaction/platform/ActivateTenantTest.java
@@ -27,7 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -60,7 +59,6 @@ public class ActivateTenantTest {
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
         activateTenant = new ActivateTenant(tenantId, platformService, schedulerService, logger, workService, connectorExecutor, plaformConfiguration,
                 tenantConfiguration);
     }

--- a/services/bonita-scheduler/bonita-scheduler-api/src/main/java/org/bonitasoft/engine/scheduler/SchedulerService.java
+++ b/services/bonita-scheduler/bonita-scheduler-api/src/main/java/org/bonitasoft/engine/scheduler/SchedulerService.java
@@ -83,7 +83,7 @@ public interface SchedulerService extends PlatformLifecycleService {
      * @throws SSchedulerException
      *         if an exception occurs.
      */
-    void schedule(SJobDescriptor jobDescriptor, List<SJobParameter> parameters, Trigger trigger) throws SSchedulerException;
+    void schedule(SJobDescriptor jobDescriptor, List<SJobParameter> jobParameters, Trigger trigger) throws SSchedulerException;
 
     void executeAgain(long jobDescriptorId) throws SSchedulerException;
 


### PR DESCRIPTION
There is now a check in start node to ensure that default jobs are deployed.
This check applies to initial startup (platform creation) and node restarts.