### PR TITLE
BS-13596/inclusive_gateway

### DIFF
--- a/bpm/bonita-core/bonita-process-instance/bonita-process-instance-api/src/main/java/org/bonitasoft/engine/core/process/instance/model/SGatewayInstance.java
+++ b/bpm/bonita-core/bonita-process-instance/bonita-process-instance-api/src/main/java/org/bonitasoft/engine/core/process/instance/model/SGatewayInstance.java
@@ -24,4 +24,6 @@ public interface SGatewayInstance extends SFlowNodeInstance {
 
     String getHitBys();
 
+    boolean isFinished();
+
 }

--- a/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/main/java/org/bonitasoft/engine/core/process/instance/impl/GatewayInstanceServiceImpl.java
+++ b/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/main/java/org/bonitasoft/engine/core/process/instance/impl/GatewayInstanceServiceImpl.java
@@ -144,6 +144,10 @@ public class GatewayInstanceServiceImpl implements GatewayInstanceService {
             logger.log(TAG, TechnicalLogSeverity.DEBUG,
                     "Evaluate if gateway " + gatewayInstance.getName() + " of instance " + gatewayInstance.getRootProcessInstanceId() + " of definition "
                             + sDefinition.getName() + " must be activated ");
+        logger.log(TAG, TechnicalLogSeverity.DEBUG, "HitBys = " + gatewayInstance.getHitBys());
+        if(gatewayInstance.isFinished()) {
+            return false;
+        }
         SFlowElementContainerDefinition processContainer = sDefinition.getProcessContainer();
         SFlowNodeDefinition gatewayDefinition = processContainer.getFlowNode(gatewayInstance.getFlowNodeDefinitionId());
         long processInstanceId = gatewayInstance.getParentContainerId();
@@ -153,7 +157,6 @@ public class GatewayInstanceServiceImpl implements GatewayInstanceService {
         List<STransitionDefinition> incomingWithTokens = new ArrayList<STransitionDefinition>();
         List<STransitionDefinition> incomingWithoutTokens = new ArrayList<STransitionDefinition>();
 
-        logger.log(TAG, TechnicalLogSeverity.DEBUG, "HitBys = " + gatewayInstance.getHitBys());
         for (int i = 0; i < incomingTransitions.size(); i++) {
             STransitionDefinition currentTransition = incomingTransitions.get(i);
             if (hitByTransitionList.contains(String.valueOf(i + 1))) {

--- a/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/main/java/org/bonitasoft/engine/core/process/instance/model/impl/SGatewayInstanceImpl.java
+++ b/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/main/java/org/bonitasoft/engine/core/process/instance/model/impl/SGatewayInstanceImpl.java
@@ -15,6 +15,7 @@ package org.bonitasoft.engine.core.process.instance.model.impl;
 
 import org.bonitasoft.engine.core.process.definition.model.SFlowNodeType;
 import org.bonitasoft.engine.core.process.definition.model.SGatewayType;
+import org.bonitasoft.engine.core.process.instance.api.GatewayInstanceService;
 import org.bonitasoft.engine.core.process.instance.model.SGatewayInstance;
 
 /**
@@ -56,6 +57,11 @@ public class SGatewayInstanceImpl extends SFlowNodeInstanceImpl implements SGate
     @Override
     public String getHitBys() {
         return hitBys;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return hitBys != null && hitBys.startsWith(GatewayInstanceService.FINISH);
     }
 
     public void setGatewayType(final SGatewayType gatewayType) {

--- a/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/test/java/org/bonitasoft/engine/core/process/instance/impl/GatewayInstanceServiceImplTest.java
+++ b/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/test/java/org/bonitasoft/engine/core/process/instance/impl/GatewayInstanceServiceImplTest.java
@@ -476,4 +476,21 @@ public class GatewayInstanceServiceImplTest {
         verify(gatewayInstanceService, times(2)).addBackwardReachableTransitions(eq(processContainer), eq(nodeDefinition), anyListOf(STransitionDefinition.class), anyListOf(STransitionDefinition.class), anyListOf(STransitionDefinition.class));
         verify(gatewayInstanceService).transitionsContainsAToken(anyListOf(STransitionDefinition.class), eq(nodeDefinition), eq(PROCESS_INSTANCE_ID), eq(processContainer));
     }
+
+    @Test
+    public void should_isInclusiveGatewayActivated_return_false_when_finished() throws SBonitaReadException {
+        SProcessDefinitionImpl processDefinition = new SProcessDefinitionImpl("P", "1.0");
+        processDefinition.setProcessContainer(processContainer);
+        SGatewayInstanceImpl gate = new SGatewayInstanceImpl();
+        gate.setName("gate");
+        gate.setHitBys("FINISH:1");
+        gate.setFlowNodeDefinitionId(50L);
+        gate.setParentContainerId(PROCESS_INSTANCE_ID);
+        node(50L, "gate");
+
+        boolean activated = gatewayInstanceService.isInclusiveGatewayActivated(processDefinition, gate);
+
+        assertThat(activated).isFalse();
+    }
+
 }

--- a/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/test/java/org/bonitasoft/engine/core/process/instance/model/impl/SGatewayInstanceImplTest.java
+++ b/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/test/java/org/bonitasoft/engine/core/process/instance/model/impl/SGatewayInstanceImplTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.core.process.instance.model.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class SGatewayInstanceImplTest {
+
+    @Test
+    public void isFinished_should_return_true_when_hitbys_starts_with_FINISH() throws Exception {
+        //given
+        SGatewayInstanceImpl gatewayInstance = buildGateWithHitBys("FINISH:1");
+
+        //when
+        gatewayInstance.isFinished();
+
+        //then
+        assertThat(gatewayInstance.isFinished()).isTrue();
+    }
+
+    @Test
+    public void isFinished_should_return_false_when_hitbys_doesnt_start_with_FINISH() throws Exception {
+        //given
+        SGatewayInstanceImpl gatewayInstance = buildGateWithHitBys("1,2");
+
+        //when
+        gatewayInstance.isFinished();
+
+        //then
+        assertThat(gatewayInstance.isFinished()).isFalse();
+    }
+
+    @Test
+    public void isFinished_should_return_false_when_hitbys_is_null() throws Exception {
+        //given
+        SGatewayInstanceImpl gatewayInstance = buildGateWithHitBys(null);
+
+        //when
+        gatewayInstance.isFinished();
+
+        //then
+        assertThat(gatewayInstance.isFinished()).isFalse();
+    }
+
+
+    private SGatewayInstanceImpl buildGateWithHitBys(final String hitBys) {
+        SGatewayInstanceImpl gatewayInstance = new SGatewayInstanceImpl();
+        gatewayInstance.setHitBys(hitBys);
+        return gatewayInstance;
+    }
+
+}


### PR DESCRIPTION
 Root cause: completed gateways (hitbys starting with 'FINISH:') were considered as active.
 Fix: handle 'FINISH:' when checking whether a gateway is active