### PR TITLE
BS-13443, deactivate tenant should pause jobs

### DIFF
--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/transaction/platform/ActivateTenant.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/transaction/platform/ActivateTenant.java
@@ -96,6 +96,7 @@ public final class ActivateTenant implements TransactionContent {
             for (final JobRegister jobRegister : jobsToRegister) {
                 registerJob(jobRegister);
             }
+            schedulerService.resumeJobs(tenantId);
         }
     }
 

--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/transaction/platform/DeactivateTenant.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/transaction/platform/DeactivateTenant.java
@@ -39,6 +39,7 @@ public final class DeactivateTenant implements TransactionContent {
     @Override
     public void execute() throws SBonitaException {
         platformService.deactiveTenant(tenantId);
+        schedulerService.pauseJobs(tenantId);
         if (schedulerService.isStarted()) {
             schedulerService.delete(ActivateTenant.BPM_EVENT_HANDLING);
             schedulerService.delete(ActivateTenant.CLEAN_INVALID_SESSIONS);

--- a/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/transaction/platform/ActivateTenantTest.java
+++ b/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/transaction/platform/ActivateTenantTest.java
@@ -15,6 +15,7 @@ package org.bonitasoft.engine.api.impl.transaction.platform;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import org.bonitasoft.engine.api.impl.NodeConfiguration;
 import org.bonitasoft.engine.api.impl.TenantConfiguration;
@@ -73,4 +74,21 @@ public class ActivateTenantTest {
         verify(connectorExecutor).start();
     }
 
+    @Test
+    public void should_resume_jobs_of_the_tenant() throws Exception {
+        given(platformService.activateTenant(tenantId)).willReturn(true);
+        activateTenant.execute();
+
+        verify(schedulerService).resumeJobs(tenantId);
+    }
+
+
+    @Test
+    public void should_not_do_anything_if_tenant_was_not_activated() throws Exception {
+        given(platformService.activateTenant(tenantId)).willReturn(false);
+        activateTenant.execute();
+
+        verifyZeroInteractions(schedulerService);
+        verifyZeroInteractions(connectorExecutor);
+    }
 }

--- a/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/transaction/platform/DeactivateTenantTest.java
+++ b/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/transaction/platform/DeactivateTenantTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.api.impl.transaction.platform;
+
+import static org.mockito.Mockito.verify;
+
+import org.bonitasoft.engine.platform.PlatformService;
+import org.bonitasoft.engine.scheduler.SchedulerService;
+import org.bonitasoft.engine.work.WorkService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author Baptiste Mesta
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DeactivateTenantTest {
+
+    private final long tenantId = 17L;
+    @Mock
+    private PlatformService platformService;
+    @Mock
+    private SchedulerService schedulerService;
+    @Mock
+    private WorkService workService;
+
+    private DeactivateTenant deactivateTenant;
+
+    @Before
+    public void setup() {
+        deactivateTenant = new DeactivateTenant(tenantId, platformService, schedulerService);
+    }
+
+    @Test
+    public void should_pause_jobs_of_the_tenant() throws Exception {
+        deactivateTenant.execute();
+
+        verify(schedulerService).pauseJobs(tenantId);
+    }
+
+}


### PR DESCRIPTION
The bug was happening when we:
 - deactivate a tenant that contains processes with start timer
 - shuting down the node
 - restarting the node
the timer were triggered even if the tenant was deactivated
in 7.0.0 the bug was less visible because work service was shutdown and not restarted with the node
however we had failed jobs

-> now the deactive/activate tenant pause and resume jobs