### PR TITLE
Fix/bs 13435 add invalid credential exception

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/platform/PlatformLoginIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/platform/PlatformLoginIT.java
@@ -34,8 +34,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +69,7 @@ public class PlatformLoginIT extends CommonAPIIT {
     };
 
     @Cover(classes = PlatformAPI.class, concept = BPMNConcept.NONE, keywords = { "Platform", "Login" }, story = "Try to log with wrong loggin.", jira = "")
-    @Test(expected = PlatformLoginException.class)
+    @Test(expected = InvalidPlatformCredentialsException.class)
     public void wrongLogin() throws BonitaException {
         try {
             platformLoginAPI.logout(session);

--- a/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/api/PlatformLoginAPI.java
+++ b/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/api/PlatformLoginAPI.java
@@ -13,6 +13,7 @@
  **/
 package org.bonitasoft.engine.api;
 
+import org.bonitasoft.engine.platform.InvalidPlatformCredentialsException;
 import org.bonitasoft.engine.platform.PlatformLoginException;
 import org.bonitasoft.engine.platform.PlatformLogoutException;
 import org.bonitasoft.engine.session.PlatformSession;
@@ -46,9 +47,11 @@ public interface PlatformLoginAPI {
      *         the session created for you, can be used to retrieve platform APIs
      * @throws PlatformLoginException
      *             occurs when an exception is thrown during login the platform
+     * @throws InvalidPlatformCredentialsException
+     *             occurs when thr username or password is not valid
      */
     @NoSessionRequired
-    PlatformSession login(String userName, String password) throws PlatformLoginException;
+    PlatformSession login(String userName, String password) throws PlatformLoginException, InvalidPlatformCredentialsException;
 
     /**
      * Logout from a platform.

--- a/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/platform/InvalidPlatformCredentialsException.java
+++ b/bpm/bonita-api/bonita-common-api/src/main/java/org/bonitasoft/engine/platform/InvalidPlatformCredentialsException.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2015 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * Copyright (C) 2015 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
  * This library is free software; you can redistribute it and/or modify it under the terms
  * of the GNU Lesser General Public License as published by the Free Software Foundation
  * version 2.1 of the License.
@@ -11,19 +11,15 @@
  * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
  * Floor, Boston, MA 02110-1301, USA.
  **/
-package org.bonitasoft.engine.core.platform.login;
 
-import org.bonitasoft.engine.commons.exceptions.SBonitaException;
+package org.bonitasoft.engine.platform;
 
 /**
- * @author Elias Ricken de Medeiros
+ * @author Baptiste Mesta
  */
-public class SPlatformLoginException extends SBonitaException {
+public class InvalidPlatformCredentialsException extends PlatformLoginException {
 
-    private static final long serialVersionUID = 4420091633702041899L;
-
-    public SPlatformLoginException(final Throwable cause) {
-        super(cause);
+    public InvalidPlatformCredentialsException(String message) {
+        super(message);
     }
-
 }

--- a/bpm/bonita-core/bonita-platform-login/bonita-platform-login-api-impl/src/main/java/org/bonitasoft/engine/core/platform/login/impl/PlatformLoginServiceImpl.java
+++ b/bpm/bonita-core/bonita-platform-login/bonita-platform-login-api-impl/src/main/java/org/bonitasoft/engine/core/platform/login/impl/PlatformLoginServiceImpl.java
@@ -14,6 +14,7 @@
 package org.bonitasoft.engine.core.platform.login.impl;
 
 import org.bonitasoft.engine.core.platform.login.PlatformLoginService;
+import org.bonitasoft.engine.core.platform.login.SInvalidPlatformCredentialsException;
 import org.bonitasoft.engine.core.platform.login.SPlatformLoginException;
 import org.bonitasoft.engine.platform.authentication.PlatformAuthenticationService;
 import org.bonitasoft.engine.platform.authentication.SInvalidPasswordException;
@@ -40,14 +41,12 @@ public class PlatformLoginServiceImpl implements PlatformLoginService {
     }
 
     @Override
-    public SPlatformSession login(final String userName, final String password) throws SPlatformLoginException {
+    public SPlatformSession login(final String userName, final String password) throws SPlatformLoginException, SInvalidPlatformCredentialsException {
         try {
             authenticationService.checkUserCredentials(userName, password);
             return sessionService.createSession(userName);
-        } catch (final SInvalidUserException e) {
-            throw new SPlatformLoginException(e);
-        } catch (final SInvalidPasswordException e) {
-            throw new SPlatformLoginException(e);
+        } catch (final SInvalidUserException | SInvalidPasswordException e) {
+            throw new SInvalidPlatformCredentialsException(e);
         } catch (final SSessionException e) {
             throw new SPlatformLoginException(e);
         }

--- a/bpm/bonita-core/bonita-platform-login/bonita-platform-login-api-impl/src/test/java/org/bonitasoft/engine/core/platform/login/impl/PlatformLoginServiceImplTest.java
+++ b/bpm/bonita-core/bonita-platform-login/bonita-platform-login-api-impl/src/test/java/org/bonitasoft/engine/core/platform/login/impl/PlatformLoginServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.bonitasoft.engine.core.platform.login.SInvalidPlatformCredentialsException;
 import org.bonitasoft.engine.core.platform.login.SPlatformLoginException;
 import org.bonitasoft.engine.platform.authentication.PlatformAuthenticationService;
 import org.bonitasoft.engine.platform.authentication.SInvalidPasswordException;
@@ -60,7 +61,7 @@ public class PlatformLoginServiceImplTest {
      * Test method for {@link org.bonitasoft.engine.core.platform.login.impl.PlatformLoginServiceImpl#login(java.lang.String, java.lang.String)}.
      */
     @Test
-    public final void login() throws SPlatformLoginException, SSessionException, SInvalidUserException, SInvalidPasswordException {
+    public final void login() throws Exception {
         final String userName = "userName";
         final String password = "pwd";
         doNothing().when(authenticationService).checkUserCredentials(userName, password);
@@ -70,8 +71,9 @@ public class PlatformLoginServiceImplTest {
         assertEquals(sPlatformSession, platformLoginServiceImpl.login(userName, password));
     }
 
-    @Test(expected = SPlatformLoginException.class)
-    public final void loginThrowSInvalidUserException() throws SPlatformLoginException, SInvalidUserException, SInvalidPasswordException {
+
+    @Test(expected = SInvalidPlatformCredentialsException.class)
+    public final void loginThrowSInvalidUserException() throws Exception {
         final String userName = "userName";
         final String password = "pwd";
         doThrow(new SInvalidUserException("")).when(authenticationService).checkUserCredentials(userName, password);
@@ -79,17 +81,18 @@ public class PlatformLoginServiceImplTest {
         platformLoginServiceImpl.login(userName, password);
     }
 
-    @Test(expected = SPlatformLoginException.class)
-    public final void loginThrowSInvalidPasswordException() throws SPlatformLoginException, SInvalidUserException, SInvalidPasswordException {
+    @Test(expected = SInvalidPlatformCredentialsException.class)
+    public final void loginThrowSInvalidPasswordException() throws Exception {
         final String userName = "userName";
         final String password = "pwd";
         doThrow(new SInvalidPasswordException("")).when(authenticationService).checkUserCredentials(userName, password);
 
-        platformLoginServiceImpl.login(userName, password);
+        platformLoginServiceImpl.login(userName,
+                password);
     }
 
     @Test(expected = SPlatformLoginException.class)
-    public final void loginThrowSSessionException() throws SPlatformLoginException, SSessionException, SInvalidUserException, SInvalidPasswordException {
+    public final void loginThrowSSessionException() throws Exception {
         final String userName = "userName";
         final String password = "pwd";
         doNothing().when(authenticationService).checkUserCredentials(userName, password);

--- a/bpm/bonita-core/bonita-platform-login/bonita-platform-login-api/src/main/java/org/bonitasoft/engine/core/platform/login/PlatformLoginService.java
+++ b/bpm/bonita-core/bonita-platform-login/bonita-platform-login-api/src/main/java/org/bonitasoft/engine/core/platform/login/PlatformLoginService.java
@@ -34,7 +34,7 @@ public interface PlatformLoginService {
      * @see SPlatformSession
      * @throws SPlatformLoginException
      */
-    SPlatformSession login(String userName, String password) throws SPlatformLoginException;
+    SPlatformSession login(String userName, String password) throws SPlatformLoginException, SInvalidPlatformCredentialsException;
 
     /**
      * logout the platform by sessionId

--- a/bpm/bonita-core/bonita-platform-login/bonita-platform-login-api/src/main/java/org/bonitasoft/engine/core/platform/login/SInvalidPlatformCredentialsException.java
+++ b/bpm/bonita-core/bonita-platform-login/bonita-platform-login-api/src/main/java/org/bonitasoft/engine/core/platform/login/SInvalidPlatformCredentialsException.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2015 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * Copyright (C) 2015 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
  * This library is free software; you can redistribute it and/or modify it under the terms
  * of the GNU Lesser General Public License as published by the Free Software Foundation
  * version 2.1 of the License.
@@ -11,19 +11,16 @@
  * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
  * Floor, Boston, MA 02110-1301, USA.
  **/
+
 package org.bonitasoft.engine.core.platform.login;
 
 import org.bonitasoft.engine.commons.exceptions.SBonitaException;
 
 /**
- * @author Elias Ricken de Medeiros
+ * @author Baptiste Mesta
  */
-public class SPlatformLoginException extends SBonitaException {
-
-    private static final long serialVersionUID = 4420091633702041899L;
-
-    public SPlatformLoginException(final Throwable cause) {
-        super(cause);
+public class SInvalidPlatformCredentialsException extends SBonitaException {
+    public SInvalidPlatformCredentialsException(Throwable e) {
+        super(e);
     }
-
 }

--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/PlatformLoginAPIImpl.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/PlatformLoginAPIImpl.java
@@ -17,10 +17,10 @@ import java.util.Date;
 
 import org.bonitasoft.engine.api.PlatformLoginAPI;
 import org.bonitasoft.engine.api.impl.transaction.CustomTransactions;
-import org.bonitasoft.engine.commons.exceptions.SBonitaException;
 import org.bonitasoft.engine.core.platform.login.PlatformLoginService;
-import org.bonitasoft.engine.log.technical.TechnicalLogSeverity;
-import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
+import org.bonitasoft.engine.core.platform.login.SInvalidPlatformCredentialsException;
+import org.bonitasoft.engine.core.platform.login.SPlatformLoginException;
+import org.bonitasoft.engine.platform.InvalidPlatformCredentialsException;
 import org.bonitasoft.engine.platform.PlatformLoginException;
 import org.bonitasoft.engine.platform.PlatformLogoutException;
 import org.bonitasoft.engine.platform.session.SSessionNotFoundException;
@@ -40,7 +40,7 @@ public class PlatformLoginAPIImpl extends AbstractLoginApiImpl implements Platfo
     @Override
     @CustomTransactions
     @AvailableOnStoppedNode
-    public PlatformSession login(final String userName, final String password) throws PlatformLoginException {
+    public PlatformSession login(final String userName, final String password) throws PlatformLoginException, InvalidPlatformCredentialsException {
         PlatformServiceAccessor platformAccessor;
         try {
             platformAccessor = ServiceAccessorFactory.getInstance().createPlatformServiceAccessor();
@@ -49,25 +49,24 @@ public class PlatformLoginAPIImpl extends AbstractLoginApiImpl implements Platfo
             throw new PlatformLoginException(e.getMessage());
         }
         final PlatformLoginService platformLoginService = platformAccessor.getPlatformLoginService();
-//        PlatformService platformService = platformAccessor.getPlatformService(); // TO UNCOMMENT lvaills
+        //        PlatformService platformService = platformAccessor.getPlatformService(); // TO UNCOMMENT lvaills
 
         // first call before create session: put the platform in cache if necessary
-//        putPlatformInCacheIfNecessary(platformAccessor, platformService); // TO UNCOMMENT lvaills
+        //        putPlatformInCacheIfNecessary(platformAccessor, platformService); // TO UNCOMMENT lvaills
 
+        final SPlatformSession platformSession;
         try {
-            final SPlatformSession platformSession = platformLoginService.login(userName, password);
-            final long id = platformSession.getId();
-            final Date creationDate = platformSession.getCreationDate();
-            final long duration = platformSession.getDuration();
-            final long userId = platformSession.getUserId();
-            return new PlatformSessionImpl(id, creationDate, duration, userName, userId);
-        } catch (final SBonitaException e) {
-            final TechnicalLoggerService technicalLoggerService = platformAccessor.getTechnicalLoggerService();
-            if (technicalLoggerService.isLoggable(this.getClass(), TechnicalLogSeverity.WARNING)) {
-                technicalLoggerService.log(this.getClass(), TechnicalLogSeverity.WARNING, e);
-            }
-            throw new PlatformLoginException(e.getMessage());
+            platformSession = platformLoginService.login(userName, password);
+        } catch (SPlatformLoginException e) {
+            throw new PlatformLoginException(e);
+        } catch (SInvalidPlatformCredentialsException ignored) {
+            throw new InvalidPlatformCredentialsException("Wrong username of password");
         }
+        final long id = platformSession.getId();
+        final Date creationDate = platformSession.getCreationDate();
+        final long duration = platformSession.getDuration();
+        final long userId = platformSession.getUserId();
+        return new PlatformSessionImpl(id, creationDate, duration, userName, userId);
     }
 
     @Override


### PR DESCRIPTION
when we login to the platform with invalid credentials an new exception named InvalidPlatformCredentialsException is thrown
it extends the PlatformLoginException to avoid api break