### PR TITLE
BS-14191,  fix getActiveGateway was returning the finished

### DIFF
--- a/bonita-integration-tests/bonita-query-tests/src/test/java/org/bonitasoft/engine/core/process/instance/model/FlowNodeInstanceTests.java
+++ b/bonita-integration-tests/bonita-query-tests/src/test/java/org/bonitasoft/engine/core/process/instance/model/FlowNodeInstanceTests.java
@@ -20,17 +20,17 @@ import static org.bonitasoft.engine.test.persistence.builder.PendingActivityMapp
 import static org.bonitasoft.engine.test.persistence.builder.ProcessInstanceBuilder.aProcessInstance;
 import static org.bonitasoft.engine.test.persistence.builder.UserBuilder.aUser;
 import static org.bonitasoft.engine.test.persistence.builder.UserMembershipBuilder.aUserMembership;
+import static org.bonitasoft.engine.test.persistence.builder.GatewayInstanceBuilder.aGatewayInstanceBuilder;
 import static org.bonitasoft.engine.test.persistence.builder.UserTaskInstanceBuilder.aUserTask;
 import static org.bonitasoft.engine.test.persistence.builder.archive.ArchivedUserTaskInstanceBuilder.anArchivedUserTask;
 
 import java.util.List;
-
 import javax.inject.Inject;
 
 import org.bonitasoft.engine.actor.mapping.model.SActor;
 import org.bonitasoft.engine.core.process.definition.model.impl.SProcessDefinitionDeployInfoImpl;
 import org.bonitasoft.engine.core.process.instance.model.archive.SAFlowNodeInstance;
-import org.bonitasoft.engine.core.process.instance.model.impl.SUserTaskInstanceImpl;
+import org.bonitasoft.engine.core.process.instance.model.impl.SGatewayInstanceImpl;
 import org.bonitasoft.engine.persistence.QueryOptions;
 import org.bonitasoft.engine.test.persistence.repository.FlowNodeInstanceRepository;
 import org.junit.Before;
@@ -388,6 +388,45 @@ public class FlowNodeInstanceTests {
         // Then
         assertThat(sHumanTaskInstances.size()).isEqualTo(2);
         assertThat(sHumanTaskInstances.get(0).getId()).isEqualTo(NORMAL_HUMAN_INSTANCE_ID);
+    }
+
+    @Test
+    public void getActiveGatewayInstance_should_return_gateway_if_not_finished() {
+        // Given
+        final SGatewayInstanceImpl gatewayInstance = aGatewayInstanceBuilder().withHitBys("1,2").withName("gate1").withTerminal(false).withLogicalGroup4(ROOT_PROCESS_INSTANCE_ID).build();
+        repository.add(gatewayInstance);
+
+        // When
+        final SGatewayInstance gate1 = repository.getActiveGatewayInstanceOfProcess(ROOT_PROCESS_INSTANCE_ID, "gate1");
+
+        // Then
+        assertThat(gate1).isEqualTo(gatewayInstance);
+    }
+
+
+    @Test
+    public void getActiveGatewayInstance_should_not_return_gateway_if_finished() {
+        // Given
+        repository.add(aGatewayInstanceBuilder().withHitBys("FINISH:1").withName("gate1").withTerminal(false).withLogicalGroup4(ROOT_PROCESS_INSTANCE_ID).build());
+
+        // When
+        final SGatewayInstance gate1 = repository.getActiveGatewayInstanceOfProcess(ROOT_PROCESS_INSTANCE_ID, "gate1");
+
+        // Then
+        assertThat(gate1).isNull();
+    }
+
+    @Test
+    public void getActiveGatewayInstance_should_not_return_gateway_if_wrong_name() {
+        // Given
+        final SGatewayInstanceImpl gatewayInstance = aGatewayInstanceBuilder().withHitBys("1,2").withName("notTheGoodGateway").withTerminal(false).withLogicalGroup4(ROOT_PROCESS_INSTANCE_ID).build();
+        repository.add(gatewayInstance);
+
+        // When
+        final SGatewayInstance gate1 = repository.getActiveGatewayInstanceOfProcess(ROOT_PROCESS_INSTANCE_ID, "gate1");
+
+        // Then
+        assertThat(gate1).isNull();
     }
 
     private void buildAndAddAssignedTasks() {

--- a/bonita-integration-tests/bonita-query-tests/src/test/java/org/bonitasoft/engine/test/persistence/repository/FlowNodeInstanceRepository.java
+++ b/bonita-integration-tests/bonita-query-tests/src/test/java/org/bonitasoft/engine/test/persistence/repository/FlowNodeInstanceRepository.java
@@ -14,10 +14,10 @@
 package org.bonitasoft.engine.test.persistence.repository;
 
 import java.util.List;
-import java.util.Map;
 
-import org.bonitasoft.engine.core.process.instance.model.SHumanTaskInstance;
 import org.bonitasoft.engine.core.process.instance.model.SFlowNodeInstanceStateCounter;
+import org.bonitasoft.engine.core.process.instance.model.SGatewayInstance;
+import org.bonitasoft.engine.core.process.instance.model.SHumanTaskInstance;
 import org.bonitasoft.engine.persistence.QueryOptions;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;
@@ -38,6 +38,14 @@ public class FlowNodeInstanceRepository extends TestRepository {
         namedQuery.setMaxResults(queryOptions.getNumberOfResults());
         namedQuery.setFirstResult(queryOptions.getFromIndex());
         return (List<Long>) namedQuery.list();
+    }
+    @SuppressWarnings("unchecked")
+    public SGatewayInstance getActiveGatewayInstanceOfProcess(long parentProcessInstanceId, String name) {
+        getSessionWithTenantFilter();
+        final Query namedQuery = getNamedQuery("getActiveGatewayInstanceOfProcess");
+        namedQuery.setParameter("parentProcessInstanceId",parentProcessInstanceId);
+        namedQuery.setParameter("name",name);
+        return (SGatewayInstance) namedQuery.uniqueResult();
     }
 
     public long getNumberOfSHumanTaskInstanceAssignedAndPendingByRootProcessFor(final long rootProcessDefinitionId, final long userId) {

--- a/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/main/resources/org/bonitasoft/engine/core/process/instance/model/impl/hibernate/process.instance.queries.hbm.xml
+++ b/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/main/resources/org/bonitasoft/engine/core/process/instance/model/impl/hibernate/process.instance.queries.hbm.xml
@@ -83,6 +83,7 @@
 		WHERE g.logicalGroup4 = :parentProcessInstanceId
 		AND g.name = :name
 		AND g.terminal = FALSE
+		AND g.hitBys NOT LIKE 'FINISH%'
 	</query>
 
 	<query name="getActivitiesWithStates">

--- a/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/test/java/org/bonitasoft/engine/core/process/instance/impl/GatewayInstanceServiceImplTest.java
+++ b/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/test/java/org/bonitasoft/engine/core/process/instance/impl/GatewayInstanceServiceImplTest.java
@@ -43,6 +43,7 @@ import org.bonitasoft.engine.core.process.instance.model.SFlowNodeInstance;
 import org.bonitasoft.engine.core.process.instance.model.SGatewayInstance;
 import org.bonitasoft.engine.core.process.instance.model.impl.SGatewayInstanceImpl;
 import org.bonitasoft.engine.core.process.instance.model.impl.SUserTaskInstanceImpl;
+import org.bonitasoft.engine.core.process.instance.recorder.SelectDescriptorBuilder;
 import org.bonitasoft.engine.events.EventService;
 import org.bonitasoft.engine.events.model.SUpdateEvent;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
@@ -509,8 +510,27 @@ public class GatewayInstanceServiceImplTest {
 
         verify(recorder).recordUpdate(updateRecordCaptor.capture(), any(SUpdateEvent.class));
 
-        assertThat(updateRecordCaptor.getValue().getFields().keySet()).contains("stateId","reachedStateDate","lastUpdateDate");
+        assertThat(updateRecordCaptor.getValue().getFields().keySet()).contains("stateId", "reachedStateDate", "lastUpdateDate");
 
+    }
+
+    @Test
+    public void should_getActiveGatewayOfProcess_return_the_gateway() throws Exception {
+        SGatewayInstanceImpl gate = new SGatewayInstanceImpl();
+        doReturn(gate).when(persistenceRead).selectOne(SelectDescriptorBuilder.getActiveGatewayInstanceOfProcess(PROCESS_INSTANCE_ID, "myGate"));
+
+        final SGatewayInstance myGate = gatewayInstanceService.getActiveGatewayInstanceOfTheProcess(PROCESS_INSTANCE_ID, "myGate");
+
+        assertThat(myGate).isEqualTo(gate);
+    }
+
+    @Test
+    public void should_getActiveGatewayOfProcess_return_null_if_not_found() throws Exception {
+        doReturn(null).when(persistenceRead).selectOne(SelectDescriptorBuilder.getActiveGatewayInstanceOfProcess(PROCESS_INSTANCE_ID, "myGate"));
+
+        final SGatewayInstance myGate = gatewayInstanceService.getActiveGatewayInstanceOfTheProcess(PROCESS_INSTANCE_ID, "myGate");
+
+        assertThat(myGate).isNull();
     }
 
 }


### PR DESCRIPTION
The finished gateway were returned by the getActiveGatewayOfProcess and because of that a single gateway was executed mutiple times

also remove the new exception when the gateway is not found and return null instead