### PR TITLE
Fix/bs 14191 gateway merge

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/process/GatewayExecutionIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/process/GatewayExecutionIT.java
@@ -740,7 +740,7 @@ public class GatewayExecutionIT extends TestWithUser {
      * Expected : step5
      * BS-13596
      */
-   @Test
+    @Test
     public void exclusiveThenInclusive() throws Exception {
         createTrueAndFalseExpression();
         final DesignProcessDefinition designProcessDefinition = new ProcessDefinitionBuilder()
@@ -749,7 +749,8 @@ public class GatewayExecutionIT extends TestWithUser {
                 .addGateway("gateway1", GatewayType.EXCLUSIVE).addGateway("gateway2", GatewayType.INCLUSIVE).addGateway("gateway3", GatewayType.INCLUSIVE)
                 .addTransition("step1", "gateway1")
                 .addTransition("gateway1", "step6", falseExpression)
-                .addDefaultTransition("gateway1", "gateway2").addTransition("gateway2", "step2", trueExpression).addTransition("gateway2", "step3", trueExpression)
+                .addDefaultTransition("gateway1", "gateway2").addTransition("gateway2", "step2", trueExpression)
+                .addTransition("gateway2", "step3", trueExpression)
                 .addDefaultTransition("gateway2", "step4").addTransition("step2", "gateway3").addTransition("step3", "gateway3")
                 .addTransition("step4", "gateway3").addTransition("gateway3", "step5").getProcess();
         final ProcessDefinition processDefinition = deployAndEnableProcessWithActor(designProcessDefinition, ACTOR_NAME, user);
@@ -803,7 +804,8 @@ public class GatewayExecutionIT extends TestWithUser {
                 .createNewInstance("My_Process_with_parallel_gateway", PROCESS_VERSION).addActor(ACTOR_NAME).addAutomaticTask("step1")
                 .addAutomaticTask("step2").addAutomaticTask("step3").addAutomaticTask("step4").addUserTask("step5", ACTOR_NAME)
                 .addGateway("gateway1", GatewayType.PARALLEL).addGateway("gateway2", GatewayType.EXCLUSIVE).addTransition("step1", "gateway1")
-                .addTransition("gateway1", "step2").addTransition("gateway1", "step3").addTransition("gateway1", "step4").addTransition("step2", "gateway2")
+                .addTransition("gateway1", "step2").addTransition("gateway1", "step3").addTransition("gateway1", "step4")
+                .addTransition("step2", "gateway2")
                 .addTransition("step3", "gateway2").addTransition("step4", "gateway2").addTransition("gateway2", "step5").getProcess();
         final ProcessDefinition processDefinition = deployAndEnableProcessWithActor(designProcessDefinition, ACTOR_NAME, user);
         final ProcessDeploymentInfo processDeploymentInfo = getProcessAPI().getProcessDeploymentInfo(processDefinition.getId());

--- a/bonita-integration-tests/bonita-query-tests/src/test/java/org/bonitasoft/engine/core/process/instance/model/FlowNodeInstanceTest.java
+++ b/bonita-integration-tests/bonita-query-tests/src/test/java/org/bonitasoft/engine/core/process/instance/model/FlowNodeInstanceTest.java
@@ -47,7 +47,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "/testContext.xml" })
 @Transactional
-public class FlowNodeInstanceTests {
+public class FlowNodeInstanceTest {
 
     private static final long GROUP_FOR_BOB_ID = 74L;
 
@@ -92,8 +92,6 @@ public class FlowNodeInstanceTests {
     public void getFlowNodeInstanceIdsToRestart_should_return_ids_of_flow_nodes_that_are_not_deleted_and_is_executing_notStable_or_terminal() {
         // given
         repository.add(aUserTask().withName("normalTask1").withStateExecuting(false).withStable(true).withTerminal(false)
-                .build());
-        repository.add(aUserTask().withName("deletedTask").withStateExecuting(false).withStable(true).withTerminal(false)
                 .build());
         final SFlowNodeInstance executing = repository.add(aUserTask().withName("executingTask").withStateExecuting(true).withStable(true).withTerminal(false)
                 .build());
@@ -175,7 +173,7 @@ public class FlowNodeInstanceTests {
                 JOHN_ID);
 
         // Then
-        assertThat(sHumanTaskInstances.size()).isEqualTo(1);
+        assertThat(sHumanTaskInstances).hasSize(1);
         assertThat(sHumanTaskInstances.get(0).getId()).isEqualTo(NORMAL_HUMAN_INSTANCE_ID);
     }
 
@@ -189,7 +187,7 @@ public class FlowNodeInstanceTests {
                 JOHN_ID);
 
         // Then
-        assertThat(sHumanTaskInstances.size()).isEqualTo(1);
+        assertThat(sHumanTaskInstances).hasSize(1);
         assertThat(sHumanTaskInstances.get(0).getId()).isEqualTo(NORMAL_HUMAN_INSTANCE_ID);
     }
 
@@ -203,7 +201,7 @@ public class FlowNodeInstanceTests {
                 JOHN_ID);
 
         // Then
-        assertThat(sHumanTaskInstances.size()).isEqualTo(1);
+        assertThat(sHumanTaskInstances).hasSize(1);
         assertThat(sHumanTaskInstances.get(0).getId()).isEqualTo(NORMAL_HUMAN_INSTANCE_ID);
     }
 
@@ -217,7 +215,7 @@ public class FlowNodeInstanceTests {
                 JOHN_ID);
 
         // Then
-        assertThat(sHumanTaskInstances.size()).isEqualTo(1);
+        assertThat(sHumanTaskInstances).hasSize(1);
         assertThat(sHumanTaskInstances.get(0).getId()).isEqualTo(NORMAL_HUMAN_INSTANCE_ID);
     }
 
@@ -347,7 +345,7 @@ public class FlowNodeInstanceTests {
         final List<SHumanTaskInstance> sHumanTaskInstances = repository.searchSHumanTaskInstanceAssignedAndPendingByRootProcess(PROCESS_DEFINITION_ID);
 
         // Then
-        assertThat(sHumanTaskInstances.size()).isEqualTo(2);
+        assertThat(sHumanTaskInstances).hasSize(2);
         assertThat(sHumanTaskInstances.get(0).getId()).isEqualTo(NORMAL_HUMAN_INSTANCE_ID);
     }
 
@@ -360,7 +358,7 @@ public class FlowNodeInstanceTests {
         final List<SHumanTaskInstance> sHumanTaskInstances = repository.searchSHumanTaskInstanceAssignedAndPendingByRootProcess(PROCESS_DEFINITION_ID);
 
         // Then
-        assertThat(sHumanTaskInstances.size()).isEqualTo(2);
+        assertThat(sHumanTaskInstances).hasSize(2);
         assertThat(sHumanTaskInstances.get(0).getId()).isEqualTo(NORMAL_HUMAN_INSTANCE_ID);
     }
 
@@ -373,7 +371,7 @@ public class FlowNodeInstanceTests {
         final List<SHumanTaskInstance> sHumanTaskInstances = repository.searchSHumanTaskInstanceAssignedAndPendingByRootProcess(PROCESS_DEFINITION_ID);
 
         // Then
-        assertThat(sHumanTaskInstances.size()).isEqualTo(2);
+        assertThat(sHumanTaskInstances).hasSize(2);
         assertThat(sHumanTaskInstances.get(0).getId()).isEqualTo(NORMAL_HUMAN_INSTANCE_ID);
     }
 
@@ -386,7 +384,7 @@ public class FlowNodeInstanceTests {
         final List<SHumanTaskInstance> sHumanTaskInstances = repository.searchSHumanTaskInstanceAssignedAndPendingByRootProcess(PROCESS_DEFINITION_ID);
 
         // Then
-        assertThat(sHumanTaskInstances.size()).isEqualTo(2);
+        assertThat(sHumanTaskInstances).hasSize(2);
         assertThat(sHumanTaskInstances.get(0).getId()).isEqualTo(NORMAL_HUMAN_INSTANCE_ID);
     }
 
@@ -435,8 +433,6 @@ public class FlowNodeInstanceTests {
                 .withRootProcessInstanceId(ROOT_PROCESS_INSTANCE_ID).withAssigneeId(JOHN_ID).withId(NORMAL_HUMAN_INSTANCE_ID).build());
 
         // Tasks KO assigned to john & OK not assigned
-        repository.add(aUserTask().withName("deletedTask").withStateExecuting(false).withStable(true).withTerminal(false)
-                .withRootProcessInstanceId(ROOT_PROCESS_INSTANCE_ID).withAssigneeId(JOHN_ID).build());
         repository.add(aUserTask().withName("executingTask").withStateExecuting(true).withStable(true).withTerminal(false)
                 .withRootProcessInstanceId(ROOT_PROCESS_INSTANCE_ID).withAssigneeId(JOHN_ID).build());
         repository.add(aUserTask().withName("notStableTask").withStateExecuting(false).withStable(false).withTerminal(true)
@@ -457,8 +453,6 @@ public class FlowNodeInstanceTests {
         repository.add(aPendingActivityMapping().withUserId(JOHN_ID).withActivityId(normalTask1.getId()).build());
 
         // Tasks KO not assigned & pending for john, and OK not assigned & not pending
-        final SFlowNodeInstance deletedTask = buildAndAddDeletedTask();
-        repository.add(aPendingActivityMapping().withUserId(JOHN_ID).withActivityId(deletedTask.getId()).build());
         final SFlowNodeInstance executingTask = buildAndAddExecutingTask();
         repository.add(aPendingActivityMapping().withUserId(JOHN_ID).withActivityId(executingTask.getId()).build());
         final SFlowNodeInstance notStableTask = buildAndAddNotStableTask();
@@ -502,8 +496,6 @@ public class FlowNodeInstanceTests {
         repository.add(aPendingActivityMapping().withActorId(actorForJohn.getId()).withActivityId(normalTask1.getId()).build());
 
         // Tasks KO not assigned & pending for john, and OK not assigned & not pending
-        final SFlowNodeInstance deletedTask = buildAndAddDeletedTask();
-        repository.add(aPendingActivityMapping().withActorId(actorForJohn.getId()).withActivityId(deletedTask.getId()).build());
         final SFlowNodeInstance executingTask = buildAndAddExecutingTask();
         repository.add(aPendingActivityMapping().withActorId(actorForJohn.getId()).withActivityId(executingTask.getId()).build());
         final SFlowNodeInstance notStableTask = buildAndAddNotStableTask();
@@ -522,10 +514,6 @@ public class FlowNodeInstanceTests {
                 .withRootProcessInstanceId(rootProcessInstanceId).build());
     }
 
-    private SFlowNodeInstance buildAndAddDeletedTask() {
-        return repository.add(aUserTask().withName("deletedTask").withStateExecuting(false).withStable(true).withTerminal(false)
-                .withRootProcessInstanceId(ROOT_PROCESS_INSTANCE_ID).build());
-    }
 
     private SFlowNodeInstance buildAndAddExecutingTask() {
         return repository.add(aUserTask().withName("executingTask").withStateExecuting(true).withStable(true)

--- a/bonita-integration-tests/bonita-query-tests/src/test/java/org/bonitasoft/engine/test/persistence/repository/FlowNodeInstanceRepository.java
+++ b/bonita-integration-tests/bonita-query-tests/src/test/java/org/bonitasoft/engine/test/persistence/repository/FlowNodeInstanceRepository.java
@@ -14,10 +14,10 @@
 package org.bonitasoft.engine.test.persistence.repository;
 
 import java.util.List;
-import java.util.Map;
 
-import org.bonitasoft.engine.core.process.instance.model.SHumanTaskInstance;
 import org.bonitasoft.engine.core.process.instance.model.SFlowNodeInstanceStateCounter;
+import org.bonitasoft.engine.core.process.instance.model.SGatewayInstance;
+import org.bonitasoft.engine.core.process.instance.model.SHumanTaskInstance;
 import org.bonitasoft.engine.persistence.QueryOptions;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;
@@ -38,6 +38,14 @@ public class FlowNodeInstanceRepository extends TestRepository {
         namedQuery.setMaxResults(queryOptions.getNumberOfResults());
         namedQuery.setFirstResult(queryOptions.getFromIndex());
         return (List<Long>) namedQuery.list();
+    }
+    @SuppressWarnings("unchecked")
+    public SGatewayInstance getActiveGatewayInstanceOfProcess(long parentProcessInstanceId, String name) {
+        getSessionWithTenantFilter();
+        final Query namedQuery = getNamedQuery("getActiveGatewayInstanceOfProcess");
+        namedQuery.setParameter("parentProcessInstanceId",parentProcessInstanceId);
+        namedQuery.setParameter("name",name);
+        return (SGatewayInstance) namedQuery.uniqueResult();
     }
 
     public long getNumberOfSHumanTaskInstanceAssignedAndPendingByRootProcessFor(final long rootProcessDefinitionId, final long userId) {

--- a/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/test/java/org/bonitasoft/engine/core/process/instance/impl/GatewayInstanceServiceImplTest.java
+++ b/bpm/bonita-core/bonita-process-instance/bonita-process-instance-impl/src/test/java/org/bonitasoft/engine/core/process/instance/impl/GatewayInstanceServiceImplTest.java
@@ -43,6 +43,7 @@ import org.bonitasoft.engine.core.process.instance.model.SFlowNodeInstance;
 import org.bonitasoft.engine.core.process.instance.model.SGatewayInstance;
 import org.bonitasoft.engine.core.process.instance.model.impl.SGatewayInstanceImpl;
 import org.bonitasoft.engine.core.process.instance.model.impl.SUserTaskInstanceImpl;
+import org.bonitasoft.engine.core.process.instance.recorder.SelectDescriptorBuilder;
 import org.bonitasoft.engine.events.EventService;
 import org.bonitasoft.engine.events.model.SUpdateEvent;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
@@ -509,8 +510,27 @@ public class GatewayInstanceServiceImplTest {
 
         verify(recorder).recordUpdate(updateRecordCaptor.capture(), any(SUpdateEvent.class));
 
-        assertThat(updateRecordCaptor.getValue().getFields().keySet()).contains("stateId","reachedStateDate","lastUpdateDate");
+        assertThat(updateRecordCaptor.getValue().getFields().keySet()).contains("stateId", "reachedStateDate", "lastUpdateDate");
 
+    }
+
+    @Test
+    public void should_getActiveGatewayOfProcess_return_the_gateway() throws Exception {
+        SGatewayInstanceImpl gate = new SGatewayInstanceImpl();
+        doReturn(gate).when(persistenceRead).selectOne(SelectDescriptorBuilder.getActiveGatewayInstanceOfProcess(PROCESS_INSTANCE_ID, "myGate"));
+
+        final SGatewayInstance myGate = gatewayInstanceService.getActiveGatewayInstanceOfTheProcess(PROCESS_INSTANCE_ID, "myGate");
+
+        assertThat(myGate).isEqualTo(gate);
+    }
+
+    @Test
+    public void should_getActiveGatewayOfProcess_return_null_if_not_found() throws Exception {
+        doReturn(null).when(persistenceRead).selectOne(SelectDescriptorBuilder.getActiveGatewayInstanceOfProcess(PROCESS_INSTANCE_ID, "myGate"));
+
+        final SGatewayInstance myGate = gatewayInstanceService.getActiveGatewayInstanceOfTheProcess(PROCESS_INSTANCE_ID, "myGate");
+
+        assertThat(myGate).isNull();
     }
 
 }


### PR DESCRIPTION
fix getActiveGateway was returning the finished
The finished gateway were returned by the getActiveGatewayOfProcess and because of that a single gateway was executed mutiple times

also remove the new exception when the gateway is not found and return null instead