### PR TITLE
BS-11905, rewrite tests to avoid random failure

### DIFF
--- a/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/TenantAdministrationAPIImplTest.java
+++ b/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/TenantAdministrationAPIImplTest.java
@@ -143,6 +143,7 @@ public class TenantAdministrationAPIImplTest {
         // Then tenant service with lifecycle should be pause
         verify(tenantManagementAPI).setTenantClassloaderAndUpdateStateOfTenantServicesWithLifecycle(eq(platformServiceAccessor), eq(tenantId),
                 isA(PauseServiceStrategy.class));
+        verify(schedulerService).pauseJobs(tenantId);
         verify(tenantManagementAPI, never()).setTenantClassloaderAndUpdateStateOfTenantServicesWithLifecycle(eq(platformServiceAccessor), eq(tenantId),
                 isA(ResumeServiceStrategy.class));
     }
@@ -162,7 +163,7 @@ public class TenantAdministrationAPIImplTest {
     @Test(expected = UpdateException.class)
     public void resume_should_throw_UpdateException_when_resuming_tenant_service_with_lifecycle_fail() throws Exception {
         // Given
-        TaskResult<Void> taskResult = new TaskResult<Void>(new SWorkException("plop"));
+        TaskResult<Void> taskResult = new TaskResult<>(new SWorkException("plop"));
         doReturn(Collections.singletonMap("workService", taskResult)).when(broadcastService).execute(any(SetServiceState.class), eq(tenantId));
 
         // When a tenant moved to available mode
@@ -172,7 +173,7 @@ public class TenantAdministrationAPIImplTest {
     @Test(expected = UpdateException.class)
     public void resume_should_throw_UpdateException_when_resuming_tenant_service_with_lifecycle_is_time_out() throws Exception {
         // Given
-        TaskResult<Void> taskResult = new TaskResult<Void>(5l, TimeUnit.HOURS);
+        TaskResult<Void> taskResult = new TaskResult<>(5l, TimeUnit.HOURS);
         doReturn(Collections.singletonMap("workService", taskResult)).when(broadcastService).execute(any(SetServiceState.class), eq(tenantId));
 
         // When a tenant moved to available mode
@@ -227,7 +228,7 @@ public class TenantAdministrationAPIImplTest {
     }
 
     @Test
-    public void resume_should_pause_jobs() throws Exception {
+    public void resume_should_resume_jobs() throws Exception {
         tenantManagementAPI.resume();
 
         verify(schedulerService).resumeJobs(tenantId);


### PR DESCRIPTION
The previous version of test was using a cycle timer start process to verify if a tenant was correctly paused.
 The behaviour of pausing jobs of a given tenant are handled by Quartz and are already tested by Unit Tests, so it's not necessary to test it in an integration test.
   After changes we only check that it's not possible to log in a paused tenant and after resuming it, we are able to log in and start a process.