### PR TITLE
BS-13885, remove unused table  arch_transition_instance

### DIFF
--- a/bpm/bonita-sql/src/main/resources/sql/h2/cleanTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/h2/cleanTables.sql
@@ -11,7 +11,6 @@ DELETE FROM process_definition;
 DELETE FROM arch_document_mapping;
 DELETE FROM document;
 DELETE FROM document_mapping;
-DELETE FROM arch_transition_instance;
 DELETE FROM arch_flownode_instance;
 DELETE FROM arch_process_instance;
 DELETE FROM arch_connector_instance;

--- a/bpm/bonita-sql/src/main/resources/sql/h2/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/h2/createTables.sql
@@ -237,29 +237,6 @@ CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(kind, logical
 CREATE INDEX idx_afi_sourceId_tenantid_kind ON arch_flownode_instance (sourceObjectId, tenantid, kind);
 CREATE INDEX idx1_arch_flownode_instance ON arch_flownode_instance (tenantId, rootContainerId, parentContainerId);
 
-CREATE TABLE arch_transition_instance (
-  tenantid BIGINT NOT NULL,
-  id BIGINT NOT NULL,
-  rootContainerId BIGINT NOT NULL,
-  parentContainerId BIGINT NOT NULL,
-  source BIGINT,
-  target BIGINT,
-  state VARCHAR(50),
-  terminal BOOLEAN NOT NULL,
-  stable BOOLEAN ,
-  stateCategory VARCHAR(50) NOT NULL,
-  logicalGroup1 BIGINT NOT NULL,
-  logicalGroup2 BIGINT NOT NULL,
-  logicalGroup3 BIGINT,
-  logicalGroup4 BIGINT NOT NULL,
-  description VARCHAR(255),
-  sourceObjectId BIGINT,
-  archiveDate BIGINT NOT NULL,
-  PRIMARY KEY (tenantid, id)
-);
-
-CREATE INDEX idx1_arch_transition_instance ON arch_transition_instance (tenantid, rootcontainerid);
-
 CREATE TABLE arch_connector_instance (
   tenantid BIGINT NOT NULL,
   id BIGINT NOT NULL,

--- a/bpm/bonita-sql/src/main/resources/sql/h2/deleteTenantObjects.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/h2/deleteTenantObjects.sql
@@ -12,7 +12,6 @@ DELETE FROM document WHERE tenantid = ${tenantid};
 DELETE FROM document_mapping WHERE tenantid = ${tenantid};
 DELETE FROM arch_flownode_instance WHERE tenantid = ${tenantid};
 DELETE FROM arch_process_instance WHERE tenantid = ${tenantid};
-DELETE FROM arch_transition_instance  WHERE tenantid = ${tenantid};
 DELETE FROM arch_connector_instance  WHERE tenantid = ${tenantid};
 DELETE FROM multi_biz_data WHERE tenantid = ${tenantid};
 DELETE FROM ref_biz_data_inst WHERE tenantid = ${tenantid};

--- a/bpm/bonita-sql/src/main/resources/sql/h2/dropTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/h2/dropTables.sql
@@ -12,7 +12,6 @@ DROP TABLE document_mapping;
 DROP TABLE document;
 DROP TABLE arch_flownode_instance;
 DROP TABLE arch_process_instance;
-DROP TABLE arch_transition_instance;
 DROP TABLE arch_connector_instance;
 DROP TABLE multi_biz_data;
 DROP TABLE ref_biz_data_inst;

--- a/bpm/bonita-sql/src/main/resources/sql/h2/postCreateStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/h2/postCreateStructure.sql
@@ -70,5 +70,4 @@ ALTER TABLE arch_document_mapping ADD CONSTRAINT fk_archdocmap_docid FOREIGN KEY
 ALTER TABLE arch_flownode_instance ADD CONSTRAINT fk_arch_flownode_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_process_comment ADD CONSTRAINT fk_arch_process_comment_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_process_instance ADD CONSTRAINT fk_arch_process_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
-ALTER TABLE arch_transition_instance ADD CONSTRAINT fk_arch_transition_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_data_instance ADD CONSTRAINT fk_arch_data_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);

--- a/bpm/bonita-sql/src/main/resources/sql/h2/preDropStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/h2/preDropStructure.sql
@@ -66,5 +66,4 @@ ALTER TABLE arch_document_mapping DROP CONSTRAINT fk_archdocmap_docid;
 ALTER TABLE arch_flownode_instance DROP CONSTRAINT fk_arch_flownode_instance_tenantId;
 ALTER TABLE arch_process_comment DROP CONSTRAINT fk_arch_process_comment_tenantId;
 ALTER TABLE arch_process_instance DROP CONSTRAINT fk_arch_process_instance_tenantId;
-ALTER TABLE arch_transition_instance DROP CONSTRAINT fk_arch_transition_instance_tenantId;
 ALTER TABLE arch_data_instance DROP CONSTRAINT fk_arch_data_instance_tenantId;

--- a/bpm/bonita-sql/src/main/resources/sql/mysql/cleanTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/mysql/cleanTables.sql
@@ -10,7 +10,6 @@ DELETE FROM process_definition;
 DELETE FROM arch_document_mapping;
 DELETE FROM document;
 DELETE FROM document_mapping;
-DELETE FROM arch_transition_instance;
 DELETE FROM arch_flownode_instance;
 DELETE FROM arch_process_instance;
 DELETE FROM arch_connector_instance;

--- a/bpm/bonita-sql/src/main/resources/sql/mysql/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/mysql/createTables.sql
@@ -241,29 +241,6 @@ CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(kind, logical
 CREATE INDEX idx_afi_sourceId_tenantid_kind ON arch_flownode_instance (sourceObjectId, tenantid, kind);
 CREATE INDEX idx1_arch_flownode_instance ON arch_flownode_instance (tenantId, rootContainerId, parentContainerId);
 
-CREATE TABLE arch_transition_instance (
-  tenantid BIGINT NOT NULL,
-  id BIGINT NOT NULL,
-  rootContainerId BIGINT NOT NULL,
-  parentContainerId BIGINT NOT NULL,
-  source BIGINT,
-  target BIGINT,
-  state VARCHAR(50),
-  terminal BOOLEAN NOT NULL,
-  stable BOOLEAN ,
-  stateCategory VARCHAR(50) NOT NULL,
-  logicalGroup1 BIGINT NOT NULL,
-  logicalGroup2 BIGINT NOT NULL,
-  logicalGroup3 BIGINT,
-  logicalGroup4 BIGINT NOT NULL,
-  description VARCHAR(255),
-  sourceObjectId BIGINT,
-  archiveDate BIGINT NOT NULL,
-  PRIMARY KEY (tenantid, id)
-) ENGINE = INNODB;
-
-CREATE INDEX idx1_arch_transition_instance ON arch_transition_instance (tenantid, rootcontainerid);
-
 CREATE TABLE arch_connector_instance (
   tenantid BIGINT NOT NULL,
   id BIGINT NOT NULL,

--- a/bpm/bonita-sql/src/main/resources/sql/mysql/deleteTenantObjects.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/mysql/deleteTenantObjects.sql
@@ -12,7 +12,6 @@ DELETE FROM document WHERE tenantid = ${tenantid};
 DELETE FROM document_mapping WHERE tenantid = ${tenantid};
 DELETE FROM arch_flownode_instance WHERE tenantid = ${tenantid};
 DELETE FROM arch_process_instance WHERE tenantid = ${tenantid};
-DELETE FROM arch_transition_instance  WHERE tenantid = ${tenantid};
 DELETE FROM arch_connector_instance  WHERE tenantid = ${tenantid};
 DELETE FROM multi_biz_data WHERE tenantid = ${tenantid};
 DELETE FROM ref_biz_data_inst WHERE tenantid = ${tenantid};

--- a/bpm/bonita-sql/src/main/resources/sql/mysql/dropTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/mysql/dropTables.sql
@@ -12,7 +12,6 @@ DROP TABLE document_mapping;
 DROP TABLE document;
 DROP TABLE arch_flownode_instance;
 DROP TABLE arch_process_instance;
-DROP TABLE arch_transition_instance;
 DROP TABLE arch_connector_instance;
 DROP TABLE multi_biz_data;
 DROP TABLE ref_biz_data_inst;

--- a/bpm/bonita-sql/src/main/resources/sql/mysql/postCreateStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/mysql/postCreateStructure.sql
@@ -70,5 +70,4 @@ ALTER TABLE arch_document_mapping ADD CONSTRAINT fk_archdocmap_docid FOREIGN KEY
 ALTER TABLE arch_flownode_instance ADD CONSTRAINT fk_arch_flownode_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_process_comment ADD CONSTRAINT fk_arch_process_comment_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_process_instance ADD CONSTRAINT fk_arch_process_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
-ALTER TABLE arch_transition_instance ADD CONSTRAINT fk_arch_transition_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_data_instance ADD CONSTRAINT fk_arch_data_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);

--- a/bpm/bonita-sql/src/main/resources/sql/mysql/preDropStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/mysql/preDropStructure.sql
@@ -65,5 +65,4 @@ ALTER TABLE arch_document_mapping DROP FOREIGN KEY fk_archdocmap_docid;
 ALTER TABLE arch_flownode_instance DROP FOREIGN KEY fk_arch_flownode_instance_tenantId;
 ALTER TABLE arch_process_comment DROP FOREIGN KEY fk_arch_process_comment_tenantId;
 ALTER TABLE arch_process_instance DROP FOREIGN KEY fk_arch_process_instance_tenantId;
-ALTER TABLE arch_transition_instance DROP FOREIGN KEY fk_arch_transition_instance_tenantId;
 ALTER TABLE arch_data_instance DROP FOREIGN KEY fk_arch_data_instance_tenantId;

--- a/bpm/bonita-sql/src/main/resources/sql/oracle/cleanTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/oracle/cleanTables.sql
@@ -10,7 +10,6 @@ DELETE FROM process_definition;
 DELETE FROM arch_document_mapping;
 DELETE FROM document;
 DELETE FROM document_mapping;
-DELETE FROM arch_transition_instance;
 DELETE FROM arch_flownode_instance;
 DELETE FROM arch_process_instance;
 DELETE FROM arch_connector_instance;

--- a/bpm/bonita-sql/src/main/resources/sql/oracle/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/oracle/createTables.sql
@@ -235,29 +235,6 @@ CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(kind, logical
 CREATE INDEX idx_afi_sourceId_tenantid_kind ON arch_flownode_instance (sourceObjectId, tenantid, kind);
 CREATE INDEX idx1_arch_flownode_instance ON arch_flownode_instance (tenantId, rootContainerId, parentContainerId);
 
-CREATE TABLE arch_transition_instance (
-  tenantid NUMBER(19, 0) NOT NULL,
-  id NUMBER(19, 0) NOT NULL,
-  rootContainerId NUMBER(19, 0) NOT NULL,
-  parentContainerId NUMBER(19, 0) NOT NULL,
-  source NUMBER(19, 0),
-  target NUMBER(19, 0),
-  state VARCHAR2(50 CHAR),
-  terminal NUMBER(1) NOT NULL,
-  stable NUMBER(1) ,
-  stateCategory VARCHAR2(50 CHAR) NOT NULL,
-  logicalGroup1 NUMBER(19, 0) NOT NULL,
-  logicalGroup2 NUMBER(19, 0) NOT NULL,
-  logicalGroup3 NUMBER(19, 0),
-  logicalGroup4 NUMBER(19, 0) NOT NULL,
-  description VARCHAR2(255 CHAR),
-  sourceObjectId NUMBER(19, 0),
-  archiveDate NUMBER(19, 0) NOT NULL,
-  PRIMARY KEY (tenantid, id)
-);
-
-CREATE INDEX idx1_arch_transition_instance ON arch_transition_instance (tenantid, rootcontainerid);
-
 CREATE TABLE arch_connector_instance (
   tenantid NUMBER(19, 0) NOT NULL,
   id NUMBER(19, 0) NOT NULL,

--- a/bpm/bonita-sql/src/main/resources/sql/oracle/deleteTenantObjects.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/oracle/deleteTenantObjects.sql
@@ -12,7 +12,6 @@ DELETE FROM document WHERE tenantid = ${tenantid};
 DELETE FROM document_mapping WHERE tenantid = ${tenantid};
 DELETE FROM arch_flownode_instance WHERE tenantid = ${tenantid};
 DELETE FROM arch_process_instance WHERE tenantid = ${tenantid};
-DELETE FROM arch_transition_instance  WHERE tenantid = ${tenantid};
 DELETE FROM arch_connector_instance  WHERE tenantid = ${tenantid};
 DELETE FROM multi_biz_data WHERE tenantid = ${tenantid};
 DELETE FROM ref_biz_data_inst WHERE tenantid = ${tenantid};

--- a/bpm/bonita-sql/src/main/resources/sql/oracle/dropTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/oracle/dropTables.sql
@@ -12,7 +12,6 @@ DROP TABLE document_mapping cascade constraints purge;
 DROP TABLE document cascade constraints purge;
 DROP TABLE arch_flownode_instance cascade constraints purge;
 DROP TABLE arch_process_instance cascade constraints purge;
-DROP TABLE arch_transition_instance cascade constraints purge;
 DROP TABLE arch_connector_instance cascade constraints purge;
 DROP TABLE multi_biz_data cascade constraints purge;
 DROP TABLE ref_biz_data_inst cascade constraints purge;

--- a/bpm/bonita-sql/src/main/resources/sql/oracle/postCreateStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/oracle/postCreateStructure.sql
@@ -34,4 +34,3 @@ ALTER TABLE arch_document_mapping ADD CONSTRAINT fk_archdocmap_docid FOREIGN KEY
 ALTER TABLE arch_flownode_instance ADD CONSTRAINT fk_AFln_tenId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_process_comment ADD CONSTRAINT fk_AProcCom_tenId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_process_instance ADD CONSTRAINT fk_AProc_tenId FOREIGN KEY (tenantid) REFERENCES tenant(id);
-ALTER TABLE arch_transition_instance ADD CONSTRAINT fk_ATrans_tenId FOREIGN KEY (tenantid) REFERENCES tenant(id);

--- a/bpm/bonita-sql/src/main/resources/sql/oracle/preDropStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/oracle/preDropStructure.sql
@@ -32,4 +32,3 @@ ALTER TABLE arch_document_mapping DROP CONSTRAINT fk_archdocmap_docid;
 ALTER TABLE arch_flownode_instance DROP CONSTRAINT fk_AFln_tenId;
 ALTER TABLE arch_process_comment DROP CONSTRAINT fk_AProcCom_tenId;
 ALTER TABLE arch_process_instance DROP CONSTRAINT fk_AProc_tenId;
-ALTER TABLE arch_transition_instance DROP CONSTRAINT fk_ATrans_tenId;

--- a/bpm/bonita-sql/src/main/resources/sql/postgres/cleanTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/postgres/cleanTables.sql
@@ -10,7 +10,6 @@ DELETE FROM process_definition;
 DELETE FROM arch_document_mapping;
 DELETE FROM document;
 DELETE FROM document_mapping;
-DELETE FROM arch_transition_instance;
 DELETE FROM arch_flownode_instance;
 DELETE FROM arch_process_instance;
 DELETE FROM arch_connector_instance;

--- a/bpm/bonita-sql/src/main/resources/sql/postgres/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/postgres/createTables.sql
@@ -237,29 +237,6 @@ CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(kind, logical
 CREATE INDEX idx_afi_sourceId_tenantid_kind ON arch_flownode_instance (sourceObjectId, tenantid, kind);
 CREATE INDEX idx1_arch_flownode_instance ON arch_flownode_instance (tenantId, rootContainerId, parentContainerId);
 
-CREATE TABLE arch_transition_instance (
-  tenantid INT8 NOT NULL,
-  id INT8 NOT NULL,
-  rootContainerId INT8 NOT NULL,
-  parentContainerId INT8 NOT NULL,
-  source INT8,
-  target INT8,
-  state VARCHAR(50),
-  terminal BOOLEAN NOT NULL,
-  stable BOOLEAN ,
-  stateCategory VARCHAR(50) NOT NULL,
-  logicalGroup1 INT8 NOT NULL,
-  logicalGroup2 INT8 NOT NULL,
-  logicalGroup3 INT8,
-  logicalGroup4 INT8 NOT NULL,
-  description VARCHAR(255),
-  sourceObjectId INT8,
-  archiveDate INT8 NOT NULL,
-  PRIMARY KEY (tenantid, id)
-);
-
-CREATE INDEX idx1_arch_transition_instance ON arch_transition_instance (tenantid, rootcontainerid);
-
 CREATE TABLE arch_connector_instance (
   tenantid INT8 NOT NULL,
   id INT8 NOT NULL,

--- a/bpm/bonita-sql/src/main/resources/sql/postgres/deleteTenantObjects.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/postgres/deleteTenantObjects.sql
@@ -12,7 +12,6 @@ DELETE FROM document WHERE tenantid = ${tenantid};
 DELETE FROM document_mapping WHERE tenantid = ${tenantid};
 DELETE FROM arch_flownode_instance WHERE tenantid = ${tenantid};
 DELETE FROM arch_process_instance WHERE tenantid = ${tenantid};
-DELETE FROM arch_transition_instance  WHERE tenantid = ${tenantid};
 DELETE FROM arch_connector_instance  WHERE tenantid = ${tenantid};
 DELETE FROM multi_biz_data WHERE tenantid = ${tenantid};
 DELETE FROM ref_biz_data_inst WHERE tenantid = ${tenantid};

--- a/bpm/bonita-sql/src/main/resources/sql/postgres/dropTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/postgres/dropTables.sql
@@ -12,7 +12,6 @@ DROP TABLE document_mapping;
 DROP TABLE document;
 DROP TABLE arch_flownode_instance;
 DROP TABLE arch_process_instance;
-DROP TABLE arch_transition_instance;
 DROP TABLE arch_connector_instance;
 DROP TABLE multi_biz_data;
 DROP TABLE ref_biz_data_inst;

--- a/bpm/bonita-sql/src/main/resources/sql/postgres/postCreateStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/postgres/postCreateStructure.sql
@@ -71,5 +71,4 @@ ALTER TABLE arch_document_mapping ADD CONSTRAINT fk_archdocmap_docid FOREIGN KEY
 ALTER TABLE arch_flownode_instance ADD CONSTRAINT fk_arch_flownode_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_process_comment ADD CONSTRAINT fk_arch_process_comment_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_process_instance ADD CONSTRAINT fk_arch_process_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
-ALTER TABLE arch_transition_instance ADD CONSTRAINT fk_arch_transition_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);
 ALTER TABLE arch_data_instance ADD CONSTRAINT fk_arch_data_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id);

--- a/bpm/bonita-sql/src/main/resources/sql/postgres/preDropStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/postgres/preDropStructure.sql
@@ -65,5 +65,4 @@ ALTER TABLE arch_document_mapping DROP CONSTRAINT fk_archdocmap_docid;
 ALTER TABLE arch_flownode_instance DROP CONSTRAINT fk_arch_flownode_instance_tenantId;
 ALTER TABLE arch_process_comment DROP CONSTRAINT fk_arch_process_comment_tenantId;
 ALTER TABLE arch_process_instance DROP CONSTRAINT fk_arch_process_instance_tenantId;
-ALTER TABLE arch_transition_instance DROP CONSTRAINT fk_arch_transition_instance_tenantId;
 ALTER TABLE arch_data_instance DROP CONSTRAINT fk_arch_data_instance_tenantId;

--- a/bpm/bonita-sql/src/main/resources/sql/sqlserver/cleanTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/sqlserver/cleanTables.sql
@@ -22,8 +22,6 @@ DELETE FROM document
 GO
 DELETE FROM document_mapping
 GO
-DELETE FROM arch_transition_instance
-GO
 DELETE FROM arch_flownode_instance
 GO
 DELETE FROM arch_process_instance

--- a/bpm/bonita-sql/src/main/resources/sql/sqlserver/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/sqlserver/createTables.sql
@@ -267,31 +267,6 @@ GO
 CREATE INDEX idx1_arch_flownode_instance ON arch_flownode_instance (tenantId, rootContainerId, parentContainerId)
 GO
 
-CREATE TABLE arch_transition_instance (
-  tenantid NUMERIC(19, 0) NOT NULL,
-  id NUMERIC(19, 0) NOT NULL,
-  rootContainerId NUMERIC(19, 0) NOT NULL,
-  parentContainerId NUMERIC(19, 0) NOT NULL,
-  source NUMERIC(19, 0),
-  target NUMERIC(19, 0),
-  state NVARCHAR(50),
-  terminal BIT NOT NULL,
-  stable BIT ,
-  stateCategory NVARCHAR(50) NOT NULL,
-  logicalGroup1 NUMERIC(19, 0) NOT NULL,
-  logicalGroup2 NUMERIC(19, 0) NOT NULL,
-  logicalGroup3 NUMERIC(19, 0),
-  logicalGroup4 NUMERIC(19, 0) NOT NULL,
-  description NVARCHAR(255),
-  sourceObjectId NUMERIC(19, 0),
-  archiveDate NUMERIC(19, 0) NOT NULL,
-  PRIMARY KEY (tenantid, id)
-)
-GO
-
-CREATE INDEX idx1_arch_transition_instance ON arch_transition_instance (tenantid, rootcontainerid)
-GO
-
 CREATE TABLE arch_connector_instance (
   tenantid NUMERIC(19, 0) NOT NULL,
   id NUMERIC(19, 0) NOT NULL,

--- a/bpm/bonita-sql/src/main/resources/sql/sqlserver/deleteTenantObjects.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/sqlserver/deleteTenantObjects.sql
@@ -26,8 +26,6 @@ DELETE FROM arch_flownode_instance WHERE tenantid = ${tenantid}
 GO
 DELETE FROM arch_process_instance WHERE tenantid = ${tenantid}
 GO
-DELETE FROM arch_transition_instance  WHERE tenantid = ${tenantid}
-GO
 DELETE FROM arch_connector_instance  WHERE tenantid = ${tenantid}
 GO
 DELETE FROM multi_biz_data WHERE tenantid = ${tenantid}

--- a/bpm/bonita-sql/src/main/resources/sql/sqlserver/dropTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/sqlserver/dropTables.sql
@@ -26,8 +26,6 @@ DROP TABLE arch_flownode_instance
 GO
 DROP TABLE arch_process_instance
 GO
-DROP TABLE arch_transition_instance
-GO
 DROP TABLE arch_connector_instance
 GO
 DROP TABLE multi_biz_data

--- a/bpm/bonita-sql/src/main/resources/sql/sqlserver/postCreateStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/sqlserver/postCreateStructure.sql
@@ -131,7 +131,5 @@ ALTER TABLE arch_process_comment ADD CONSTRAINT fk_arch_process_comment_tenantId
 GO
 ALTER TABLE arch_process_instance ADD CONSTRAINT fk_arch_process_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id)
 GO
-ALTER TABLE arch_transition_instance ADD CONSTRAINT fk_arch_transition_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id)
-GO
 ALTER TABLE arch_data_instance ADD CONSTRAINT fk_arch_data_instance_tenantId FOREIGN KEY (tenantid) REFERENCES tenant(id)
 GO

--- a/bpm/bonita-sql/src/main/resources/sql/sqlserver/preDropStructure.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/sqlserver/preDropStructure.sql
@@ -124,7 +124,5 @@ ALTER TABLE arch_process_comment DROP CONSTRAINT fk_arch_process_comment_tenantI
 GO
 ALTER TABLE arch_process_instance DROP CONSTRAINT fk_arch_process_instance_tenantId
 GO
-ALTER TABLE arch_transition_instance DROP CONSTRAINT fk_arch_transition_instance_tenantId
-GO
 ALTER TABLE arch_data_instance DROP CONSTRAINT fk_arch_data_instance_tenantId
 GO


### PR DESCRIPTION
This table was supposed to be removed from scripts in version 7.0.0, but it was missed.
Note: the migration tool will need to also delete this table for installations 7.0.x and 7.1.0