### PR TITLE
Feat/EB-51 correct tests

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/activity/HumanTasksIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/activity/HumanTasksIT.java
@@ -64,8 +64,8 @@ public class HumanTasksIT extends TestWithUser {
     "Column too short" })
     @Test
     public void can_creatte_FlowNodeInstance_with_several_non_ascii_characters() throws Exception {
-        final String taskDisplayName = "Žingsnis, kuriame paraiškos teikėjas gali laisvai užpildyti duomenis, ąčęė ";
-        final String taskName = "task1क्तु क्तु क्तु क्तु क्तु paraiškos teikėjas Ž";
+        final String taskDisplayName = "àéò€çhahaאת ארץ בדפים מוסיקה לעברית. בקר גם טיפול פיסיקה, דת מתן בישול רומנית תחבורה. אל בידור מדויקים ואלקטרוניקה זאת נפלו.أملاً النزاع الصعداء بل الى. ان اتفاقية بالمطالبة ويكيبيديا، جُل. في كان بالجانب والديون الإتفاقية. لها المسرح وبولندا وبلجيكا، أي.";
+        final String taskName = "task1क्तु क्तु क्तु क्तु क्तु paraiškos teikėjas Žcheck this out 新フリぶ番高ホアリメ医意治せ羽装セヱ青済ルよじえ痛楽ぜは性位加嶋ケナ日者コ球量ミルシ異本たてふ火8在な日治じわあひ掲図トおぜ発審員ルをさレ。小スユヱイ写多キクオラ里数ンたレだ異分準ヲ念67券ド角続構ソ打政リレウテ社式築ワカエ川顔せー料開みドょわ北真メヲ齢記ヒチ山抱診露えっン。載ル定出へえぴ勝上ふのこ八抹なおぞ現負よッや新4省1開盛ょべせ東87令計のご導応ヘユレ対純霊真接スさほ。";
 
         final ProcessDefinitionBuilder processBuilder = new ProcessDefinitionBuilder().createNewInstance(PROCESS_NAME, PROCESS_VERSION);
         processBuilder.addActor(ACTOR_NAME);

--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/identity/GroupIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/identity/GroupIT.java
@@ -523,7 +523,7 @@ public class GroupIT extends TestWithTechnicalUser {
         final Group groupD = createGroup("d", "labelD", "descrtptionD");
 
         final SearchOptionsBuilder builder = new SearchOptionsBuilder(0, 10);
-        builder.filter(GroupSearchDescriptor.ID, String.valueOf(groupC.getId()));
+        builder.filter(GroupSearchDescriptor.ID, groupC.getId());
         final SearchResult<Group> searchGroups = getIdentityAPI().searchGroups(builder.done());
         assertNotNull(searchGroups);
         assertEquals(1, searchGroups.getCount());

--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/identity/RoleIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/identity/RoleIT.java
@@ -114,7 +114,7 @@ public class RoleIT extends TestWithTechnicalUser {
 
     @Test
     public void roleNameAndDisplayNameShouldAccept255Chars() throws BonitaException {
-        final String stringIndex_255_chars = "abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy12345";
+        final String stringIndex_255_chars = "a\uD83C\uDC40\uD83C\uDCBDツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッツッ";
         final Role role = getIdentityAPI().createRole(new RoleCreator(stringIndex_255_chars).setDisplayName(stringIndex_255_chars));
 
         // Should be no exception:
@@ -124,13 +124,13 @@ public class RoleIT extends TestWithTechnicalUser {
 
     @Test(expected = Exception.class)
     public void roleNameShouldNotAccept256Chars() throws BonitaException {
-        final String stringIndex_256_chars = "_abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy12345";
+        final String stringIndex_256_chars = "ッッッシシジジッシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシシ";
         getIdentityAPI().createRole(stringIndex_256_chars);
     }
 
     @Test(expected = Exception.class)
     public void roleDisplayNameShouldNotAccept256Chars() throws BonitaException {
-        final String stringIndex_256_chars = "_abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy12345";
+        final String stringIndex_256_chars = "ッッッツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツツヅ";
         getIdentityAPI().createRole(new RoleCreator("someName").setDisplayName(stringIndex_256_chars));
     }
 

--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/identity/UserIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/identity/UserIT.java
@@ -858,7 +858,7 @@ public class UserIT extends TestWithTechnicalUser {
         getIdentityAPI().addUserMemberships(Arrays.asList(john1.getId(), jack.getId()), group.getId(), role.getId());
 
         final SearchOptionsBuilder builder = new SearchOptionsBuilder(0, 10);
-        builder.filter(UserSearchDescriptor.GROUP_ID, String.valueOf(group.getId()));
+        builder.filter(UserSearchDescriptor.GROUP_ID, (Long) group.getId());
         builder.sort(UserSearchDescriptor.USER_NAME, Order.DESC);
         final SearchResult<User> searchUsers = getIdentityAPI().searchUsers(builder.done());
         assertNotNull(searchUsers);
@@ -884,7 +884,7 @@ public class UserIT extends TestWithTechnicalUser {
         getIdentityAPI().addUserMemberships(Arrays.asList(john1.getId(), jack.getId()), group.getId(), role.getId());
 
         final SearchOptionsBuilder builder = new SearchOptionsBuilder(0, 10);
-        builder.filter(UserSearchDescriptor.ROLE_ID, String.valueOf(role.getId()));
+        builder.filter(UserSearchDescriptor.ROLE_ID, (Long) role.getId());
         builder.sort(UserSearchDescriptor.USER_NAME, Order.ASC);
         final SearchResult<User> searchUsers = getIdentityAPI().searchUsers(builder.done());
         assertNotNull(searchUsers);
@@ -914,8 +914,8 @@ public class UserIT extends TestWithTechnicalUser {
         getIdentityAPI().addUserMemberships(Arrays.asList(john2.getId(), jack.getId()), group1.getId(), role2.getId());
 
         final SearchOptionsBuilder builder = new SearchOptionsBuilder(0, 10);
-        builder.filter(UserSearchDescriptor.GROUP_ID, String.valueOf(group2.getId()));
-        builder.filter(UserSearchDescriptor.ROLE_ID, String.valueOf(role1.getId()));
+        builder.filter(UserSearchDescriptor.GROUP_ID, group2.getId());
+        builder.filter(UserSearchDescriptor.ROLE_ID, role1.getId());
         builder.sort(UserSearchDescriptor.USER_NAME, Order.ASC);
         final SearchResult<User> searchUsers = getIdentityAPI().searchUsers(builder.done());
         assertNotNull(searchUsers);
@@ -937,7 +937,7 @@ public class UserIT extends TestWithTechnicalUser {
         final User john = getIdentityAPI().createUser("john001", "bpm", "John", "Smith");
 
         final SearchOptionsBuilder builder = new SearchOptionsBuilder(0, 10);
-        builder.filter(UserSearchDescriptor.MANAGER_USER_ID, manager.getId());
+        builder.filter(UserSearchDescriptor.MANAGER_USER_ID, (Long) manager.getId());
         final SearchResult<User> searchUsers = getIdentityAPI().searchUsers(builder.done());
         assertNotNull(searchUsers);
         assertEquals(1, searchUsers.getCount());


### PR DESCRIPTION
Correction on some tests:
- string values passed instead of integers in some tests made them fail on db2 & derby (as they are more strong typed on strings than other vendors)
- better utf8 tests (they could not pass in db2 as it uses byte sized varchars, and some tests used vanilla ascii characters instead of utf8)