### PR TITLE
Feat/EB-51 materialized blob

### DIFF
--- a/bpm/bonita-core/bonita-document/bonita-document-impl/src/main/resources/org/bonitasoft/engine/core/document/model/impl/hibernate/document.hbm.xml
+++ b/bpm/bonita-core/bonita-document/bonita-document-impl/src/main/resources/org/bonitasoft/engine/core/document/model/impl/hibernate/document.hbm.xml
@@ -46,7 +46,7 @@
         <property name="fileName" type="string" column="filename"/>
         <property name="mimeType" type="string" column="mimetype"/>
         <property name="url" type="string" column="url"/>
-        <property name="content" column="content"/>
+        <property name="content" type="materialized_blob" column="content"/>
         <filter name="tenantFilter"/>
     </class>
 

--- a/bpm/bonita-core/bonita-process-definition/bonita-process-definition-impl/src/main/resources/org/bonitasoft/engine/core/process/definition/model/impl/hibernate/process.definition.hbm.xml
+++ b/bpm/bonita-core/bonita-process-definition/bonita-process-definition-impl/src/main/resources/org/bonitasoft/engine/core/process/definition/model/impl/hibernate/process.definition.hbm.xml
@@ -35,7 +35,7 @@
             <key-property name="tenantId" column="tenantid" type="long" />
             <key-property name="id" column="id" type="long" />
         </composite-id>
-        <property name="content" column="content" />
+        <property name="content" type="materialized_clob" column="content" />
     </class>
 
 </hibernate-mapping>

--- a/services/bonita-data-instance/bonita-data-instance-impl/src/main/resources/org/bonitasoft/engine/data/instance/model/impl/hibernate/archived.data.instance.hbm.xml
+++ b/services/bonita-data-instance/bonita-data-instance-impl/src/main/resources/org/bonitasoft/engine/data/instance/model/impl/hibernate/archived.data.instance.hbm.xml
@@ -62,7 +62,7 @@
 	</subclass>
 
 	<subclass name="SABlobDataInstanceImpl" abstract="false" discriminator-value="SABlobDataInstanceImpl" extends="SADataInstanceImpl">
-		<property name="value" column="blobValue" />
+		<property name="value" column="blobValue" type="materialized_blob" />
 	</subclass>
 
 	<subclass name="SADateDataInstanceImpl" abstract="false" discriminator-value="SADateDataInstanceImpl" extends="SADataInstanceImpl">

--- a/services/bonita-data-instance/bonita-data-instance-impl/src/main/resources/org/bonitasoft/engine/data/instance/model/impl/hibernate/data.instance.hbm.xml
+++ b/services/bonita-data-instance/bonita-data-instance-impl/src/main/resources/org/bonitasoft/engine/data/instance/model/impl/hibernate/data.instance.hbm.xml
@@ -56,7 +56,7 @@
 	</subclass>
 
 	<subclass name="SBlobDataInstanceImpl" abstract="false" discriminator-value="SBlobDataInstanceImpl" extends="SDataInstanceImpl">
-		<property name="value" column="blobValue" />
+		<property name="value" column="blobValue" type="materialized_blob" />
 	</subclass>
 
 	<subclass name="SXMLObjectDataInstanceImpl" abstract="false" discriminator-value="SXMLObjectDataInstanceImpl" extends="SDataInstanceImpl">

--- a/services/bonita-page/bonita-page-impl/src/main/resources/org/bonitasoft/engine/page/impl/hibernate/page.hbm.xml
+++ b/services/bonita-page/bonita-page-impl/src/main/resources/org/bonitasoft/engine/page/impl/hibernate/page.hbm.xml
@@ -39,7 +39,7 @@
 		<property name="lastModificationDate" column="lastModificationDate" />
 		<property name="lastUpdatedBy" column="lastUpdatedBy" />
 		<property name="contentName" column="contentName" />
-		<property name="content" column="content" />
+		<property name="content" column="content" type="materialized_blob" />
         <property name="contentType" column="contentType" />
         <property name="processDefinitionId" column="processDefinitionId" />
 		<filter name="tenantFilter" />
@@ -50,7 +50,7 @@
             <key-property name="tenantId" column="tenantId" type="long" />
             <key-property name="id" column="id" type="long" />
         </composite-id>
-        <property name="content" column="content" />
+        <property name="content" column="content" type="materialized_blob" />
         <filter name="tenantFilter" />
     </class>
 

--- a/services/bonita-persistence/bonita-persistence-hibernate/src/main/java/org/bonitasoft/engine/persistence/AbstractHibernatePersistenceService.java
+++ b/services/bonita-persistence/bonita-persistence-hibernate/src/main/java/org/bonitasoft/engine/persistence/AbstractHibernatePersistenceService.java
@@ -13,21 +13,12 @@
  **/
 package org.bonitasoft.engine.persistence;
 
-import static org.bonitasoft.engine.persistence.search.FilterOperationType.L_PARENTHESIS;
-import static org.bonitasoft.engine.persistence.search.FilterOperationType.R_PARENTHESIS;
-import static org.bonitasoft.engine.persistence.search.FilterOperationType.isNormalOperator;
+import static org.bonitasoft.engine.persistence.search.FilterOperationType.*;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
 import javax.sql.DataSource;
+import java.lang.InstantiationException;
+import java.util.*;
+import java.util.Map.Entry;
 
 import org.bonitasoft.engine.commons.ClassReflector;
 import org.bonitasoft.engine.commons.EnumToObjectConvertible;
@@ -37,13 +28,7 @@ import org.bonitasoft.engine.persistence.search.FilterOperationType;
 import org.bonitasoft.engine.sequence.SequenceManager;
 import org.bonitasoft.engine.services.SPersistenceException;
 import org.bonitasoft.engine.services.UpdateDescriptor;
-import org.hibernate.AssertionFailure;
-import org.hibernate.HibernateException;
-import org.hibernate.Interceptor;
-import org.hibernate.Query;
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.StaleStateException;
+import org.hibernate.*;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.exception.LockAcquisitionException;
 import org.hibernate.mapping.PersistentClass;
@@ -58,6 +43,7 @@ import org.hibernate.stat.Statistics;
  * @author Matthieu Chaffotte
  * @author Celine Souchet
  * @author Laurent Vaills
+ * @author Guillaume Rosinosky
  */
 public abstract class AbstractHibernatePersistenceService extends AbstractDBPersistenceService {
 
@@ -140,6 +126,7 @@ public abstract class AbstractHibernatePersistenceService extends AbstractDBPers
         if (dialect != null) {
             if (dialect.contains("PostgreSQL")) {
                 configuration.setInterceptor(new PostgresInterceptor());
+                configuration.registerTypeOverride(new PostgresMaterializedBlobType());
             } else if (dialect.contains("SQLServer")) {
                 configuration.setInterceptor(new SQLServerInterceptor());
             }

--- a/services/bonita-persistence/bonita-persistence-hibernate/src/main/java/org/bonitasoft/engine/persistence/PostgresMaterializedBlobType.java
+++ b/services/bonita-persistence/bonita-persistence-hibernate/src/main/java/org/bonitasoft/engine/persistence/PostgresMaterializedBlobType.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 BonitaSoft S.A.
+ * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.persistence;
+
+import org.hibernate.type.AbstractSingleColumnStandardBasicType;
+import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
+import org.hibernate.type.descriptor.sql.BinaryTypeDescriptor;
+
+/**
+ * @author Guillaume Rosinosky
+ */
+public class PostgresMaterializedBlobType extends AbstractSingleColumnStandardBasicType<byte[]> {
+    public PostgresMaterializedBlobType() {
+        // mapping binary to byte[] (for bytea type in Postgres)
+        super(BinaryTypeDescriptor.INSTANCE , PrimitiveByteArrayTypeDescriptor.INSTANCE);
+    }
+
+    @Override
+    public String getName() {
+        return "materialized_blob";
+    }
+
+}

--- a/services/bonita-theme/bonita-theme-impl/src/main/resources/org/bonitasoft/engine/theme/model/impl/hibernate/theme.hbm.xml
+++ b/services/bonita-theme/bonita-theme-impl/src/main/resources/org/bonitasoft/engine/theme/model/impl/hibernate/theme.hbm.xml
@@ -12,8 +12,8 @@
 			<key-property name="id" column="id" type="long" />
 		</composite-id>
 		<property name="isDefault" column="isDefault" />
-		<property name="content" column="content" />
-		<property name="cssContent" column="cssContent" />
+		<property name="content" column="content" type="materialized_blob"/>
+		<property name="cssContent" column="cssContent" type="materialized_blob" />
 		<property name="lastUpdateDate" column="lastUpdateDate" />
 		<property name="type" column="type">
 			<type name="org.bonitasoft.engine.persistence.GenericEnumUserType">


### PR DESCRIPTION
Hibernate mapping should precise field types materialized_blob and materialized_clob for byte array[] mapping to BLOBs and CLOBs. Some vendors such as db2 and derby need it. And it's a better practice.
As we use bytea fields for BLOBs in Postgres, and Hibernate PSQL dialect uses oid instead, added an overload class for byte[] mapping so it maps to bytea and everything works as before.
No such problem for all the other db vendors.
