### PR TITLE
BS-9986, try to fix unstable  WorkServiceTest

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-local/src/test/java/org/bonitasoft/engine/continuation/WorkServiceTest.java
+++ b/bonita-integration-tests/bonita-integration-tests-local/src/test/java/org/bonitasoft/engine/continuation/WorkServiceTest.java
@@ -16,6 +16,7 @@ package org.bonitasoft.engine.continuation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.bonitasoft.engine.bpm.CommonBPMServicesTest;
@@ -54,7 +55,7 @@ public class WorkServiceTest extends CommonBPMServicesTest {
     @Test
     public void testWorkInMultipleTransactions() throws Exception {
         getTransactionService().begin();
-        final List<String> works = new ArrayList<>();
+        final List<String> works = Collections.synchronizedList(new ArrayList<String>());
         final WorkService workService = getWorkService();
         workService.registerWork(new ListAdder(works, "1"));
         getTransactionService().complete();
@@ -73,7 +74,7 @@ public class WorkServiceTest extends CommonBPMServicesTest {
     @Test
     public void testMultipleContinuation() throws Exception {
         getTransactionService().begin();
-        final List<String> works = new ArrayList<>();
+        final List<String> works = Collections.synchronizedList(new ArrayList<String>());
         getWorkService().registerWork(new ListAdder(works, "1"));
         getWorkService().registerWork(new ListAdder(works, "2"));
 
@@ -87,9 +88,9 @@ public class WorkServiceTest extends CommonBPMServicesTest {
     }
 
     public void waitFor(final int expected, final List<String> works) throws InterruptedException {
-        final long timeout = System.currentTimeMillis() + 2000;
+        final long timeout = System.currentTimeMillis() + 3000;
         boolean reached = false;
-        int size = -1;
+        int size;
         do {
             size = works.size();
             if (size == expected) {


### PR DESCRIPTION
Mark shared list used in test as synchronized. Before using a synchronized list I was able to reproduce the issue by executing the test many times (iterate 5000 times),
   with synchronized list I was unable to reproduce the issue even iterating 10000 times.