### PR TITLE
BS-14371, avoid variable names conflicts

### DIFF
--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/EqualsBuilder.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/EqualsBuilder.java
@@ -19,6 +19,7 @@ import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JConditional;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JFieldRef;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
@@ -45,16 +46,20 @@ public class EqualsBuilder {
             final JFieldVar fieldVar = field.getValue();
             final JType type = fieldVar.type();
             if (type.isPrimitive()) {
-                body._if(JExpr.ref(fieldVar.name()).ne(other.ref(fieldVar.name())))._then()._return(JExpr.FALSE);
+                body._if(buildFieldRef(fieldVar).ne(other.ref(fieldVar.name())))._then()._return(JExpr.FALSE);
             } else {
-                final JConditional ifRefIsNull = body._if(JExpr.ref(fieldVar.name()).eq(JExpr._null()));
+                final JConditional ifRefIsNull = body._if(buildFieldRef(fieldVar).eq(JExpr._null()));
                 ifRefIsNull._then()._if(other.ref(fieldVar.name()).ne(JExpr._null()))._then()._return(JExpr.FALSE);
-                ifRefIsNull._elseif(JExpr.ref(fieldVar.name()).invoke("equals").arg(other.ref(fieldVar.name())).not())._then()._return(JExpr.FALSE);
+                ifRefIsNull._elseif(buildFieldRef(fieldVar).invoke("equals").arg(other.ref(fieldVar.name())).not())._then()._return(JExpr.FALSE);
             }
         }
 
         body._return(JExpr.TRUE);
         return equalsMethod;
+    }
+
+    private JFieldRef buildFieldRef(JFieldVar fieldVar) {
+        return JExpr._this().ref(fieldVar);
     }
 
 }

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/EqualsBuilder.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/EqualsBuilder.java
@@ -13,13 +13,14 @@
  **/
 package org.bonitasoft.engine.bdm;
 
+import static org.bonitasoft.engine.bdm.JExprHelper.buildFieldRef;
+
 import java.util.Map.Entry;
 
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JConditional;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
-import com.sun.codemodel.JFieldRef;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
@@ -56,10 +57,6 @@ public class EqualsBuilder {
 
         body._return(JExpr.TRUE);
         return equalsMethod;
-    }
-
-    private JFieldRef buildFieldRef(JFieldVar fieldVar) {
-        return JExpr._this().ref(fieldVar);
     }
 
 }

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/HashCodeBuilder.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/HashCodeBuilder.java
@@ -58,7 +58,7 @@ public class HashCodeBuilder {
                             result,
                             prime.mul(result).plus(
                                     JExpr.cast(JType.parse(definedClass.owner(), int.class.getName()),
-                                            JExpr.direct("this." + fieldVar.name() + " ^ (this." + fieldVar.name() + " >>> 32)"))));
+                                            buildFieldRef(fieldVar).xor(buildFieldRef(fieldVar).shrz(JExpr.lit(32))))));
                 } else if (type.name().equals(double.class.getSimpleName())) {
                     final JClass doubleType = definedClass.owner().ref(Double.class.getName());
                     final JVar temp = body.decl(JType.parse(definedClass.owner(), long.class.getName()), fieldVar.name() + "temp",
@@ -67,7 +67,7 @@ public class HashCodeBuilder {
                             result,
                             prime.mul(result).plus(
                                     JExpr.cast(JType.parse(definedClass.owner(), int.class.getName()),
-                                            JExpr.direct(temp.name() + " ^ (" + temp.name() + " >>> 32)"))));
+                                            temp.xor(temp.shrz(JExpr.lit(32))))));
                 } else if (type.name().equals(float.class.getSimpleName())) {
                     final JClass floatType = definedClass.owner().ref(Float.class.getName());
                     body.assign(result, prime.mul(result).plus(floatType.staticInvoke("floatToIntBits").arg(buildFieldRef(fieldVar))));

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/HashCodeBuilder.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/HashCodeBuilder.java
@@ -13,13 +13,14 @@
  **/
 package org.bonitasoft.engine.bdm;
 
+import static org.bonitasoft.engine.bdm.JExprHelper.buildFieldRef;
+
 import java.util.Map.Entry;
 
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
-import com.sun.codemodel.JFieldRef;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
@@ -77,10 +78,6 @@ public class HashCodeBuilder {
 
         body._return(result);
         return hashCodeMethod;
-    }
-
-    private JFieldRef buildFieldRef(JFieldVar fieldVar) {
-        return JExpr._this().ref(fieldVar);
     }
 
 }

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/JExprHelper.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/bdm/JExprHelper.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.bdm;
+
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JFieldRef;
+import com.sun.codemodel.JFieldVar;
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+public class JExprHelper {
+
+    /**
+     * Build a {@link JFieldRef} prefixed by {@code 'this.'}
+     * @param fieldVar field to be referenced via {@code 'this.'}
+     * @return a {@link JFieldRef} prefixed by {@code 'this.'}
+     */
+    public static JFieldRef buildFieldRef(JFieldVar fieldVar) {
+        return JExpr._this().ref(fieldVar);
+    }
+
+}

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/CodeGeneratorTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/CodeGeneratorTest.java
@@ -249,13 +249,6 @@ public class CodeGeneratorTest {
     }
 
     @Test
-    public void shouldAddEqualsMethod_GenerateAnEqualsMethod_BasedOnDefinedClassFields() {
-        System.err
-                .println(
-                        "***************** PLEASE Implement test org.bonitasoft.engine.bdm.CodeGeneratorTest.shouldAddEqualsMethod_GenerateAnEqualsMethod_BasedOnDefinedClassFields() *************");
-    }
-
-    @Test
     public void should_add_and_remove_generate_on_boolean_list() throws Exception {
         //given
         final JDefinedClass definedClass = codeGenerator.addClass("org.bonitasoft.Demo");

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/CodeGeneratorTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/CodeGeneratorTest.java
@@ -27,12 +27,11 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
 import org.apache.commons.io.FileUtils;
-import org.bonitasoft.engine.bdm.CodeGenerator;
+import org.bonitasoft.engine.bdm.model.field.FieldType;
+import org.bonitasoft.engine.bdm.model.field.SimpleField;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.bonitasoft.engine.bdm.model.field.FieldType;
-import org.bonitasoft.engine.bdm.model.field.SimpleField;
 import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JDefinedClass;
@@ -252,7 +251,8 @@ public class CodeGeneratorTest {
     @Test
     public void shouldAddEqualsMethod_GenerateAnEqualsMethod_BasedOnDefinedClassFields() {
         System.err
-                .println("***************** PLEASE Implement test org.bonitasoft.engine.bdm.CodeGeneratorTest.shouldAddEqualsMethod_GenerateAnEqualsMethod_BasedOnDefinedClassFields() *************");
+                .println(
+                        "***************** PLEASE Implement test org.bonitasoft.engine.bdm.CodeGeneratorTest.shouldAddEqualsMethod_GenerateAnEqualsMethod_BasedOnDefinedClassFields() *************");
     }
 
     @Test

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/EqualsBuilderTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/EqualsBuilderTest.java
@@ -57,6 +57,7 @@ public class EqualsBuilderTest extends CompilableCode {
         final JDefinedClass definedClass = codeGenerator.addClass("org.bonitasoft.Entity");
         codeGenerator.addField(definedClass, "name", String.class);
         codeGenerator.addField(definedClass, "age", Integer.class);
+        codeGenerator.addField(definedClass, "agePr", int.class);
         codeGenerator.addField(definedClass, "returnDate", codeGenerator.getModel().ref(Date.class));
         final JMethod equalsMethod = equalsBuilder.generate(definedClass);
         assertThat(equalsMethod).isNotNull();
@@ -69,7 +70,9 @@ public class EqualsBuilderTest extends CompilableCode {
         assertThat(body.getContents()).isNotEmpty();
 
         codeGenerator.getModel().build(destDir);
-        assertCompilationSuccessful(new File(destDir, "org" + File.separatorChar + "bonitasoft" + File.separatorChar + "Entity.java"));
+        File generatedFile = new File(destDir, "org" + File.separatorChar + "bonitasoft" + File.separatorChar + "Entity.java");
+        assertCompilationSuccessful(generatedFile);
+        assertThat(generatedFile).hasContentEqualTo(new File(getClass().getResource("Entity_equals.java.txt").toURI()));
     }
 
 }

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/HashCodeBuilderTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/HashCodeBuilderTest.java
@@ -56,11 +56,17 @@ public class HashCodeBuilderTest extends CompilableCode {
     public void shouldGenerate_AddHashCodeJMethodInDefinedClass() throws Exception {
         final JDefinedClass definedClass = codeGenerator.addClass("org.bonitasoft.Entity");
         codeGenerator.addField(definedClass, "name", String.class);
+        codeGenerator.addField(definedClass, "nameCode", String.class);
         codeGenerator.addField(definedClass, "age", Integer.class);
+        codeGenerator.addField(definedClass, "agePr", int.class);
         codeGenerator.addField(definedClass, "height", Float.class);
+        codeGenerator.addField(definedClass, "heightPR", float.class);
         codeGenerator.addField(definedClass, "isMarried", Boolean.class);
+        codeGenerator.addField(definedClass, "isMarriedPr", boolean.class);
         codeGenerator.addField(definedClass, "timestamp", Long.class);
+        codeGenerator.addField(definedClass, "timestampPr", long.class);
         codeGenerator.addField(definedClass, "weight", Double.class);
+        codeGenerator.addField(definedClass, "weightPr", double.class);
         codeGenerator.addField(definedClass, "returnDate", codeGenerator.getModel().ref(Date.class));
         final JMethod hashcodeMethod = hashCodeBuilder.generate(definedClass);
         assertThat(hashcodeMethod).isNotNull();
@@ -73,7 +79,9 @@ public class HashCodeBuilderTest extends CompilableCode {
         assertThat(body.getContents()).isNotEmpty();
 
         codeGenerator.getModel().build(destDir);
-        assertCompilationSuccessful(new File(destDir, "org" + File.separatorChar + "bonitasoft" + File.separatorChar + "Entity.java"));
+        File file = new File(destDir, "org" + File.separatorChar + "bonitasoft" + File.separatorChar + "Entity.java");
+        assertCompilationSuccessful(file);
+        assertThat(file).hasContentEqualTo(new File(getClass().getResource("Entity_hashCode.java.txt").toURI()));
     }
 
 }

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/Entity_equals.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/Entity_equals.java.txt
@@ -1,0 +1,57 @@
+
+package org.bonitasoft;
+
+import java.util.Date;
+
+public class Entity {
+
+    private String name;
+    private Integer age;
+    private int agePr;
+    private Date returnDate;
+
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass()!= obj.getClass()) {
+            return false;
+        }
+        Entity other = ((Entity) obj);
+        if (this.name == null) {
+            if (other.name!= null) {
+                return false;
+            }
+        } else {
+            if (!this.name.equals(other.name)) {
+                return false;
+            }
+        }
+        if (this.age == null) {
+            if (other.age!= null) {
+                return false;
+            }
+        } else {
+            if (!this.age.equals(other.age)) {
+                return false;
+            }
+        }
+        if (this.agePr!= other.agePr) {
+            return false;
+        }
+        if (this.returnDate == null) {
+            if (other.returnDate!= null) {
+                return false;
+            }
+        } else {
+            if (!this.returnDate.equals(other.returnDate)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/Entity_hashCode.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/Entity_hashCode.java.txt
@@ -1,0 +1,78 @@
+
+package org.bonitasoft;
+
+import java.util.Date;
+
+public class Entity {
+
+    private String name;
+    private String nameCode;
+    private Integer age;
+    private int agePr;
+    private Float height;
+    private float heightPR;
+    private Boolean isMarried;
+    private boolean isMarriedPr;
+    private Long timestamp;
+    private long timestampPr;
+    private Double weight;
+    private double weightPr;
+    private Date returnDate;
+
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        int nameCode = 0;
+        if (this.name!= null) {
+            nameCode = this.name.hashCode();
+        }
+        result = ((prime*result)+ nameCode);
+        int nameCodeCode = 0;
+        if (this.nameCode!= null) {
+            nameCodeCode = this.nameCode.hashCode();
+        }
+        result = ((prime*result)+ nameCodeCode);
+        int ageCode = 0;
+        if (this.age!= null) {
+            ageCode = this.age.hashCode();
+        }
+        result = ((prime*result)+ ageCode);
+        result = ((prime*result)+ this.agePr);
+        int heightCode = 0;
+        if (this.height!= null) {
+            heightCode = this.height.hashCode();
+        }
+        result = ((prime*result)+ heightCode);
+        result = ((prime*result)+ Float.floatToIntBits(this.heightPR));
+        int isMarriedCode = 0;
+        if (this.isMarried!= null) {
+            isMarriedCode = this.isMarried.hashCode();
+        }
+        result = ((prime*result)+ isMarriedCode);
+        int isMarriedPrCode = 1237;
+        if (this.isMarriedPr) {
+            isMarriedPrCode = 1231;
+        }
+        result = ((prime*result)+ isMarriedPrCode);
+        int timestampCode = 0;
+        if (this.timestamp!= null) {
+            timestampCode = this.timestamp.hashCode();
+        }
+        result = ((prime*result)+ timestampCode);
+        result = ((prime*result)+((int)(this.timestampPr ^ (this.timestampPr >>> 32))));
+        int weightCode = 0;
+        if (this.weight!= null) {
+            weightCode = this.weight.hashCode();
+        }
+        result = ((prime*result)+ weightCode);
+        long weightPrtemp = Double.doubleToLongBits(this.weightPr);
+        result = ((prime*result)+((int)(weightPrtemp ^ (weightPrtemp >>> 32))));
+        int returnDateCode = 0;
+        if (this.returnDate!= null) {
+            returnDateCode = this.returnDate.hashCode();
+        }
+        result = ((prime*result)+ returnDateCode);
+        return result;
+    }
+
+}

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/Entity_hashCode.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/Entity_hashCode.java.txt
@@ -59,14 +59,14 @@ public class Entity {
             timestampCode = this.timestamp.hashCode();
         }
         result = ((prime*result)+ timestampCode);
-        result = ((prime*result)+((int)(this.timestampPr ^ (this.timestampPr >>> 32))));
+        result = ((prime*result)+((int)(this.timestampPr^(this.timestampPr >>> 32))));
         int weightCode = 0;
         if (this.weight!= null) {
             weightCode = this.weight.hashCode();
         }
         result = ((prime*result)+ weightCode);
         long weightPrtemp = Double.doubleToLongBits(this.weightPr);
-        result = ((prime*result)+((int)(weightPrtemp ^ (weightPrtemp >>> 32))));
+        result = ((prime*result)+((int)(weightPrtemp^(weightPrtemp >>> 32))));
         int returnDateCode = 0;
         if (this.returnDate!= null) {
             returnDateCode = this.returnDate.hashCode();

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/Employee.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/Employee.java.txt
@@ -72,30 +72,30 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
             return false;
         }
         Employee other = ((Employee) obj);
-        if (persistenceId == null) {
+        if (this.persistenceId == null) {
             if (other.persistenceId!= null) {
                 return false;
             }
         } else {
-            if (!persistenceId.equals(other.persistenceId)) {
+            if (!this.persistenceId.equals(other.persistenceId)) {
                 return false;
             }
         }
-        if (persistenceVersion == null) {
+        if (this.persistenceVersion == null) {
             if (other.persistenceVersion!= null) {
                 return false;
             }
         } else {
-            if (!persistenceVersion.equals(other.persistenceVersion)) {
+            if (!this.persistenceVersion.equals(other.persistenceVersion)) {
                 return false;
             }
         }
-        if (firstName == null) {
+        if (this.firstName == null) {
             if (other.firstName!= null) {
                 return false;
             }
         } else {
-            if (!firstName.equals(other.firstName)) {
+            if (!this.firstName.equals(other.firstName)) {
                 return false;
             }
         }
@@ -107,18 +107,18 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
         final int prime = 31;
         int result = 1;
         int persistenceIdCode = 0;
-        if (persistenceId!= null) {
-            persistenceIdCode = persistenceId.hashCode();
+        if (this.persistenceId!= null) {
+            persistenceIdCode = this.persistenceId.hashCode();
         }
         result = ((prime*result)+ persistenceIdCode);
         int persistenceVersionCode = 0;
-        if (persistenceVersion!= null) {
-            persistenceVersionCode = persistenceVersion.hashCode();
+        if (this.persistenceVersion!= null) {
+            persistenceVersionCode = this.persistenceVersion.hashCode();
         }
         result = ((prime*result)+ persistenceVersionCode);
         int firstNameCode = 0;
-        if (firstName!= null) {
-            firstNameCode = firstName.hashCode();
+        if (this.firstName!= null) {
+            firstNameCode = this.firstName.hashCode();
         }
         result = ((prime*result)+ firstNameCode);
         return result;

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/EmployeeListAggregation.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/EmployeeListAggregation.java.txt
@@ -106,39 +106,39 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
             return false;
         }
         Employee other = ((Employee) obj);
-        if (persistenceId == null) {
+        if (this.persistenceId == null) {
             if (other.persistenceId!= null) {
                 return false;
             }
         } else {
-            if (!persistenceId.equals(other.persistenceId)) {
+            if (!this.persistenceId.equals(other.persistenceId)) {
                 return false;
             }
         }
-        if (persistenceVersion == null) {
+        if (this.persistenceVersion == null) {
             if (other.persistenceVersion!= null) {
                 return false;
             }
         } else {
-            if (!persistenceVersion.equals(other.persistenceVersion)) {
+            if (!this.persistenceVersion.equals(other.persistenceVersion)) {
                 return false;
             }
         }
-        if (firstName == null) {
+        if (this.firstName == null) {
             if (other.firstName!= null) {
                 return false;
             }
         } else {
-            if (!firstName.equals(other.firstName)) {
+            if (!this.firstName.equals(other.firstName)) {
                 return false;
             }
         }
-        if (addresses == null) {
+        if (this.addresses == null) {
             if (other.addresses!= null) {
                 return false;
             }
         } else {
-            if (!addresses.equals(other.addresses)) {
+            if (!this.addresses.equals(other.addresses)) {
                 return false;
             }
         }
@@ -150,23 +150,23 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
         final int prime = 31;
         int result = 1;
         int persistenceIdCode = 0;
-        if (persistenceId!= null) {
-            persistenceIdCode = persistenceId.hashCode();
+        if (this.persistenceId!= null) {
+            persistenceIdCode = this.persistenceId.hashCode();
         }
         result = ((prime*result)+ persistenceIdCode);
         int persistenceVersionCode = 0;
-        if (persistenceVersion!= null) {
-            persistenceVersionCode = persistenceVersion.hashCode();
+        if (this.persistenceVersion!= null) {
+            persistenceVersionCode = this.persistenceVersion.hashCode();
         }
         result = ((prime*result)+ persistenceVersionCode);
         int firstNameCode = 0;
-        if (firstName!= null) {
-            firstNameCode = firstName.hashCode();
+        if (this.firstName!= null) {
+            firstNameCode = this.firstName.hashCode();
         }
         result = ((prime*result)+ firstNameCode);
         int addressesCode = 0;
-        if (addresses!= null) {
-            addressesCode = addresses.hashCode();
+        if (this.addresses!= null) {
+            addressesCode = this.addresses.hashCode();
         }
         result = ((prime*result)+ addressesCode);
         return result;

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/EmployeeListComposition.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/EmployeeListComposition.java.txt
@@ -132,48 +132,48 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
             return false;
         }
         Employee other = ((Employee) obj);
-        if (persistenceId == null) {
+        if (this.persistenceId == null) {
             if (other.persistenceId!= null) {
                 return false;
             }
         } else {
-            if (!persistenceId.equals(other.persistenceId)) {
+            if (!this.persistenceId.equals(other.persistenceId)) {
                 return false;
             }
         }
-        if (persistenceVersion == null) {
+        if (this.persistenceVersion == null) {
             if (other.persistenceVersion!= null) {
                 return false;
             }
         } else {
-            if (!persistenceVersion.equals(other.persistenceVersion)) {
+            if (!this.persistenceVersion.equals(other.persistenceVersion)) {
                 return false;
             }
         }
-        if (firstName == null) {
+        if (this.firstName == null) {
             if (other.firstName!= null) {
                 return false;
             }
         } else {
-            if (!firstName.equals(other.firstName)) {
+            if (!this.firstName.equals(other.firstName)) {
                 return false;
             }
         }
-        if (addresses == null) {
+        if (this.addresses == null) {
             if (other.addresses!= null) {
                 return false;
             }
         } else {
-            if (!addresses.equals(other.addresses)) {
+            if (!this.addresses.equals(other.addresses)) {
                 return false;
             }
         }
-        if (skills == null) {
+        if (this.skills == null) {
             if (other.skills!= null) {
                 return false;
             }
         } else {
-            if (!skills.equals(other.skills)) {
+            if (!this.skills.equals(other.skills)) {
                 return false;
             }
         }
@@ -185,28 +185,28 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
         final int prime = 31;
         int result = 1;
         int persistenceIdCode = 0;
-        if (persistenceId!= null) {
-            persistenceIdCode = persistenceId.hashCode();
+        if (this.persistenceId!= null) {
+            persistenceIdCode = this.persistenceId.hashCode();
         }
         result = ((prime*result)+ persistenceIdCode);
         int persistenceVersionCode = 0;
-        if (persistenceVersion!= null) {
-            persistenceVersionCode = persistenceVersion.hashCode();
+        if (this.persistenceVersion!= null) {
+            persistenceVersionCode = this.persistenceVersion.hashCode();
         }
         result = ((prime*result)+ persistenceVersionCode);
         int firstNameCode = 0;
-        if (firstName!= null) {
-            firstNameCode = firstName.hashCode();
+        if (this.firstName!= null) {
+            firstNameCode = this.firstName.hashCode();
         }
         result = ((prime*result)+ firstNameCode);
         int addressesCode = 0;
-        if (addresses!= null) {
-            addressesCode = addresses.hashCode();
+        if (this.addresses!= null) {
+            addressesCode = this.addresses.hashCode();
         }
         result = ((prime*result)+ addressesCode);
         int skillsCode = 0;
-        if (skills!= null) {
-            skillsCode = skills.hashCode();
+        if (this.skills!= null) {
+            skillsCode = this.skills.hashCode();
         }
         result = ((prime*result)+ skillsCode);
         return result;

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/EmployeeSimpleAggregation.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/EmployeeSimpleAggregation.java.txt
@@ -82,39 +82,39 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
             return false;
         }
         Employee other = ((Employee) obj);
-        if (persistenceId == null) {
+        if (this.persistenceId == null) {
             if (other.persistenceId!= null) {
                 return false;
             }
         } else {
-            if (!persistenceId.equals(other.persistenceId)) {
+            if (!this.persistenceId.equals(other.persistenceId)) {
                 return false;
             }
         }
-        if (persistenceVersion == null) {
+        if (this.persistenceVersion == null) {
             if (other.persistenceVersion!= null) {
                 return false;
             }
         } else {
-            if (!persistenceVersion.equals(other.persistenceVersion)) {
+            if (!this.persistenceVersion.equals(other.persistenceVersion)) {
                 return false;
             }
         }
-        if (firstName == null) {
+        if (this.firstName == null) {
             if (other.firstName!= null) {
                 return false;
             }
         } else {
-            if (!firstName.equals(other.firstName)) {
+            if (!this.firstName.equals(other.firstName)) {
                 return false;
             }
         }
-        if (address == null) {
+        if (this.address == null) {
             if (other.address!= null) {
                 return false;
             }
         } else {
-            if (!address.equals(other.address)) {
+            if (!this.address.equals(other.address)) {
                 return false;
             }
         }
@@ -126,23 +126,23 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
         final int prime = 31;
         int result = 1;
         int persistenceIdCode = 0;
-        if (persistenceId!= null) {
-            persistenceIdCode = persistenceId.hashCode();
+        if (this.persistenceId!= null) {
+            persistenceIdCode = this.persistenceId.hashCode();
         }
         result = ((prime*result)+ persistenceIdCode);
         int persistenceVersionCode = 0;
-        if (persistenceVersion!= null) {
-            persistenceVersionCode = persistenceVersion.hashCode();
+        if (this.persistenceVersion!= null) {
+            persistenceVersionCode = this.persistenceVersion.hashCode();
         }
         result = ((prime*result)+ persistenceVersionCode);
         int firstNameCode = 0;
-        if (firstName!= null) {
-            firstNameCode = firstName.hashCode();
+        if (this.firstName!= null) {
+            firstNameCode = this.firstName.hashCode();
         }
         result = ((prime*result)+ firstNameCode);
         int addressCode = 0;
-        if (address!= null) {
-            addressCode = address.hashCode();
+        if (this.address!= null) {
+            addressCode = this.address.hashCode();
         }
         result = ((prime*result)+ addressCode);
         return result;

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/EmployeeSimpleComposition.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/EmployeeSimpleComposition.java.txt
@@ -82,39 +82,39 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
             return false;
         }
         Employee other = ((Employee) obj);
-        if (persistenceId == null) {
+        if (this.persistenceId == null) {
             if (other.persistenceId!= null) {
                 return false;
             }
         } else {
-            if (!persistenceId.equals(other.persistenceId)) {
+            if (!this.persistenceId.equals(other.persistenceId)) {
                 return false;
             }
         }
-        if (persistenceVersion == null) {
+        if (this.persistenceVersion == null) {
             if (other.persistenceVersion!= null) {
                 return false;
             }
         } else {
-            if (!persistenceVersion.equals(other.persistenceVersion)) {
+            if (!this.persistenceVersion.equals(other.persistenceVersion)) {
                 return false;
             }
         }
-        if (firstName == null) {
+        if (this.firstName == null) {
             if (other.firstName!= null) {
                 return false;
             }
         } else {
-            if (!firstName.equals(other.firstName)) {
+            if (!this.firstName.equals(other.firstName)) {
                 return false;
             }
         }
-        if (address == null) {
+        if (this.address == null) {
             if (other.address!= null) {
                 return false;
             }
         } else {
-            if (!address.equals(other.address)) {
+            if (!this.address.equals(other.address)) {
                 return false;
             }
         }
@@ -126,23 +126,23 @@ public class Employee implements org.bonitasoft.engine.bdm.Entity
         final int prime = 31;
         int result = 1;
         int persistenceIdCode = 0;
-        if (persistenceId!= null) {
-            persistenceIdCode = persistenceId.hashCode();
+        if (this.persistenceId!= null) {
+            persistenceIdCode = this.persistenceId.hashCode();
         }
         result = ((prime*result)+ persistenceIdCode);
         int persistenceVersionCode = 0;
-        if (persistenceVersion!= null) {
-            persistenceVersionCode = persistenceVersion.hashCode();
+        if (this.persistenceVersion!= null) {
+            persistenceVersionCode = this.persistenceVersion.hashCode();
         }
         result = ((prime*result)+ persistenceVersionCode);
         int firstNameCode = 0;
-        if (firstName!= null) {
-            firstNameCode = firstName.hashCode();
+        if (this.firstName!= null) {
+            firstNameCode = this.firstName.hashCode();
         }
         result = ((prime*result)+ firstNameCode);
         int addressCode = 0;
-        if (address!= null) {
-            addressCode = address.hashCode();
+        if (this.address!= null) {
+            addressCode = this.address.hashCode();
         }
         result = ((prime*result)+ addressCode);
         return result;

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/ForecastList.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/ForecastList.java.txt
@@ -88,30 +88,30 @@ public class Forecast implements org.bonitasoft.engine.bdm.Entity
             return false;
         }
         Forecast other = ((Forecast) obj);
-        if (persistenceId == null) {
+        if (this.persistenceId == null) {
             if (other.persistenceId!= null) {
                 return false;
             }
         } else {
-            if (!persistenceId.equals(other.persistenceId)) {
+            if (!this.persistenceId.equals(other.persistenceId)) {
                 return false;
             }
         }
-        if (persistenceVersion == null) {
+        if (this.persistenceVersion == null) {
             if (other.persistenceVersion!= null) {
                 return false;
             }
         } else {
-            if (!persistenceVersion.equals(other.persistenceVersion)) {
+            if (!this.persistenceVersion.equals(other.persistenceVersion)) {
                 return false;
             }
         }
-        if (temperatures == null) {
+        if (this.temperatures == null) {
             if (other.temperatures!= null) {
                 return false;
             }
         } else {
-            if (!temperatures.equals(other.temperatures)) {
+            if (!this.temperatures.equals(other.temperatures)) {
                 return false;
             }
         }
@@ -123,18 +123,18 @@ public class Forecast implements org.bonitasoft.engine.bdm.Entity
         final int prime = 31;
         int result = 1;
         int persistenceIdCode = 0;
-        if (persistenceId!= null) {
-            persistenceIdCode = persistenceId.hashCode();
+        if (this.persistenceId!= null) {
+            persistenceIdCode = this.persistenceId.hashCode();
         }
         result = ((prime*result)+ persistenceIdCode);
         int persistenceVersionCode = 0;
-        if (persistenceVersion!= null) {
-            persistenceVersionCode = persistenceVersion.hashCode();
+        if (this.persistenceVersion!= null) {
+            persistenceVersionCode = this.persistenceVersion.hashCode();
         }
         result = ((prime*result)+ persistenceVersionCode);
         int temperaturesCode = 0;
-        if (temperatures!= null) {
-            temperaturesCode = temperatures.hashCode();
+        if (this.temperatures!= null) {
+            temperaturesCode = this.temperatures.hashCode();
         }
         result = ((prime*result)+ temperaturesCode);
         return result;

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/Skill.java.txt
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/resources/org/bonitasoft/engine/bdm/client/Skill.java.txt
@@ -68,30 +68,30 @@ public class Skill implements org.bonitasoft.engine.bdm.Entity
             return false;
         }
         Skill other = ((Skill) obj);
-        if (persistenceId == null) {
+        if (this.persistenceId == null) {
             if (other.persistenceId!= null) {
                 return false;
             }
         } else {
-            if (!persistenceId.equals(other.persistenceId)) {
+            if (!this.persistenceId.equals(other.persistenceId)) {
                 return false;
             }
         }
-        if (persistenceVersion == null) {
+        if (this.persistenceVersion == null) {
             if (other.persistenceVersion!= null) {
                 return false;
             }
         } else {
-            if (!persistenceVersion.equals(other.persistenceVersion)) {
+            if (!this.persistenceVersion.equals(other.persistenceVersion)) {
                 return false;
             }
         }
-        if (skill == null) {
+        if (this.skill == null) {
             if (other.skill!= null) {
                 return false;
             }
         } else {
-            if (!skill.equals(other.skill)) {
+            if (!this.skill.equals(other.skill)) {
                 return false;
             }
         }
@@ -103,18 +103,18 @@ public class Skill implements org.bonitasoft.engine.bdm.Entity
         final int prime = 31;
         int result = 1;
         int persistenceIdCode = 0;
-        if (persistenceId!= null) {
-            persistenceIdCode = persistenceId.hashCode();
+        if (this.persistenceId!= null) {
+            persistenceIdCode = this.persistenceId.hashCode();
         }
         result = ((prime*result)+ persistenceIdCode);
         int persistenceVersionCode = 0;
-        if (persistenceVersion!= null) {
-            persistenceVersionCode = persistenceVersion.hashCode();
+        if (this.persistenceVersion!= null) {
+            persistenceVersionCode = this.persistenceVersion.hashCode();
         }
         result = ((prime*result)+ persistenceVersionCode);
         int skillCode = 0;
-        if (skill!= null) {
-            skillCode = skill.hashCode();
+        if (this.skill!= null) {
+            skillCode = this.skill.hashCode();
         }
         result = ((prime*result)+ skillCode);
         return result;


### PR DESCRIPTION
The generated method 'hashcode' declares a local variable suffixed by  'Code', this local variable will hide the global variable named '*Code' causing the compilation error.
 To solve the issue, all global variables were prefixed b y 'this.'

 The same fix was done for 'equals' method.