### PR TITLE
BS-14495, discard XStream instance when the classLoader is destroyed

### DIFF
--- a/services/bonita-classloader/bonita-classloader-impl/src/main/java/org/bonitasoft/engine/classloader/VirtualClassLoader.java
+++ b/services/bonita-classloader/bonita-classloader-impl/src/main/java/org/bonitasoft/engine/classloader/VirtualClassLoader.java
@@ -18,6 +18,8 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
 
+import org.bonitasoft.engine.data.instance.model.impl.XStreamFactory;
+
 /**
  * @author Elias Ricken de Medeiros
  * @author Charles Souillard
@@ -96,6 +98,7 @@ public class VirtualClassLoader extends ClassLoader {
     }
 
     public void destroy() {
+        XStreamFactory.remove(this);
         if (classloader != null) {
             classloader.destroy();
         }

--- a/services/bonita-commons/src/main/java/org/bonitasoft/engine/data/instance/model/impl/XStreamFactory.java
+++ b/services/bonita-commons/src/main/java/org/bonitasoft/engine/data/instance/model/impl/XStreamFactory.java
@@ -21,7 +21,7 @@ import com.thoughtworks.xstream.io.xml.StaxDriver;
 
 public class XStreamFactory {
 
-    private static final Map<ClassLoader, XStream> XSTREAM_MAP = new WeakHashMap<ClassLoader, XStream>();
+    private static final Map<ClassLoader, XStream> XSTREAM_MAP = new WeakHashMap<>();
 
     public static XStream getXStream() {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
@@ -31,5 +31,13 @@ public class XStreamFactory {
             XSTREAM_MAP.put(classLoader, xStream);
         }
         return xStream;
+    }
+
+    /**
+     * Removes the XStream object related from given ClassLoader from the cache
+     * @param classLoader classLoader related to the XStreamObject to be removed.
+     */
+    public static void remove(ClassLoader classLoader) {
+        XSTREAM_MAP.remove(classLoader);
     }
 }


### PR DESCRIPTION
  Cause: XStreamFactory keeps a map ClassLoader -> XStream instance: when VirtualClassLoader.destroy()  is called the referenced BonitaClassLoader is destroyed,
   but the VirtualClassLoader itself is remains and will be used to reference a new BonitaClassLoader. In this way, the map of XStreamFactory keep the entry containing
   a XStream instance pointing to the destroyed BonitaClassLoader.

   Fix: remove the entry related to the VirtualClassLoader being destroyed when VirtualClassLoader.destroy() is called.