### PR TITLE
BS-14258, catch throwable on groovy scripts

### DIFF
--- a/bpm/bonita-connector-service/bonita-connector-service-api-impl/src/main/java/org/bonitasoft/engine/core/connector/impl/ConnectorServiceImpl.java
+++ b/bpm/bonita-connector-service/bonita-connector-service-api-impl/src/main/java/org/bonitasoft/engine/core/connector/impl/ConnectorServiceImpl.java
@@ -319,9 +319,7 @@ public class ConnectorServiceImpl implements ConnectorService {
             throw new SConnectorException(implementationClassName + " can not be found.", e);
         } catch (final InstantiationException e) {
             throw new SConnectorException(implementationClassName + " can not be instantiated.", e);
-        } catch (final IllegalAccessException e) {
-            throw new SConnectorException(e);
-        } catch (final org.bonitasoft.engine.connector.exception.SConnectorException e) {
+        } catch (final IllegalAccessException | org.bonitasoft.engine.connector.exception.SConnectorException e) {
             throw new SConnectorException(e);
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);

--- a/services/bonita-connector-executor/bonita-connector-executor-api-impl/src/main/java/org/bonitasoft/engine/connector/impl/ConnectorExecutorImpl.java
+++ b/services/bonita-connector-executor/bonita-connector-executor-api-impl/src/main/java/org/bonitasoft/engine/connector/impl/ConnectorExecutorImpl.java
@@ -120,10 +120,7 @@ public class ConnectorExecutorImpl implements ConnectorExecutor {
         final Future<Map<String, Object>> submit = executorService.submit(callable);
         try {
             return getValue(submit);
-        } catch (final InterruptedException e) {
-            disconnectSilently(sConnector);
-            throw new SConnectorException(e);
-        } catch (final ExecutionException e) {
+        } catch (final InterruptedException | ExecutionException e) {
             disconnectSilently(sConnector);
             throw new SConnectorException(e);
         } catch (final TimeoutException e) {

--- a/services/bonita-expression/bonita-expression-api-impl/src/main/java/org/bonitasoft/engine/expression/impl/GroovyScriptExpressionExecutorCacheStrategy.java
+++ b/services/bonita-expression/bonita-expression-api-impl/src/main/java/org/bonitasoft/engine/expression/impl/GroovyScriptExpressionExecutorCacheStrategy.java
@@ -142,7 +142,8 @@ public class GroovyScriptExpressionExecutorCacheStrategy extends AbstractGroovyS
         } catch (final SClassLoaderException e) {
             throw new SExpressionEvaluationException("Unable to retrieve the correct classloader to execute the groovy script : " + expression, e,
                     expressionName);
-        } catch (final Exception e) {
+        } catch (final Throwable e) {
+            //catch throwable because we do not handle contents of scripts
             String message = e.getMessage();
             if (message == null || message.isEmpty()) {
                 message = "No message";


### PR DESCRIPTION
If a script was throwing a throwable it was not catch by the expression executor resulting in unexpected behavior on the rest of the engine

Fixed it by catching throwable in the groovy script executor