### PR TITLE
ctivate error log for test in case of failure

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-local/src/main/resources/logback-test.xml
+++ b/bonita-integration-tests/bonita-integration-tests-local/src/main/resources/logback-test.xml
@@ -8,7 +8,7 @@
 	</appender>
 
 	<logger name="org.bonitasoft" level="WARN" />
-	<logger name="org.bonitasoft.engine.execution.work.FailureHandlingBonitaWork" level="OFF" />
+	<logger name="org.bonitasoft.engine.execution.work.FailureHandlingBonitaWork" level="WARN" />
 
 	<root level="WARN">
 		<appender-ref ref="STDOUT" />


### PR DESCRIPTION
reactivate FailureHandlingWork logging because it was hidding failing work in test logs