### PR TITLE
BS-14485, escape string in search

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/process/GatewayExecutionIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/process/GatewayExecutionIT.java
@@ -74,13 +74,13 @@ public class GatewayExecutionIT extends TestWithUser {
         builder.addUserTask("step2", ACTOR_NAME);
         builder.addUserTask("step3", ACTOR_NAME);
         builder.addUserTask("step4", ACTOR_NAME);
-        builder.addGateway("gatewayOne", GatewayType.INCLUSIVE)
+        builder.addGateway("d'stàp", GatewayType.INCLUSIVE)
                 .addDisplayDescriptionAfterCompletion(new ExpressionBuilder().createConstantStringExpression("description after completion"))
                 .addDisplayName(new ExpressionBuilder().createConstantStringExpression("display name"));
-        builder.addTransition("step1", "gatewayOne");
-        builder.addTransition("gatewayOne", "step2", falseExpression);
-        builder.addTransition("gatewayOne", "step3", falseExpression)
-                .addDefaultTransition("gatewayOne", "step4");
+        builder.addTransition("step1", "d'stàp");
+        builder.addTransition("d'stàp", "step2", falseExpression);
+        builder.addTransition("d'stàp", "step3", falseExpression)
+                .addDefaultTransition("d'stàp", "step4");
         final DesignProcessDefinition designProcessDefinition = builder.getProcess();
 
         final ProcessDefinition processDefinition = deployAndEnableProcessWithActor(designProcessDefinition, ACTOR_NAME, user);
@@ -96,7 +96,7 @@ public class GatewayExecutionIT extends TestWithUser {
         final SearchOptionsBuilder builder0 = new SearchOptionsBuilder(0, 10);
         builder0.filter(FlowNodeInstanceSearchDescriptor.PARENT_PROCESS_INSTANCE_ID, processInstance.getId());
         builder0.filter(FlowNodeInstanceSearchDescriptor.STATE_NAME, "completed");
-        builder0.filter(FlowNodeInstanceSearchDescriptor.NAME, "gatewayOne");
+        builder0.filter(FlowNodeInstanceSearchDescriptor.NAME, "d'stàp");
         final SearchResult<FlowNodeInstance> searchResult0 = getProcessAPI().searchFlowNodeInstances(builder0.done());
         assertEquals(0, searchResult0.getCount());
 
@@ -112,7 +112,7 @@ public class GatewayExecutionIT extends TestWithUser {
         builder1 = new SearchOptionsBuilder(0, 10);
         builder1.filter(ArchivedFlowNodeInstanceSearchDescriptor.FLOW_NODE_TYPE, "gate");
         builder1.filter(ArchivedFlowNodeInstanceSearchDescriptor.PARENT_PROCESS_INSTANCE_ID, processInstance.getId());
-        builder1.filter(ArchivedFlowNodeInstanceSearchDescriptor.NAME, "gatewayOne");
+        builder1.filter(ArchivedFlowNodeInstanceSearchDescriptor.NAME, "d'stàp");
         builder1.filter(ArchivedFlowNodeInstanceSearchDescriptor.STATE_NAME, "completed");
         final ArchivedFlowNodeInstance gatewayOne = getProcessAPI().searchArchivedFlowNodeInstances(builder1.done()).getResult().get(0);
         // we expect all normal gateway states to be archived:

--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/search/SearchActivityInstanceIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/search/SearchActivityInstanceIT.java
@@ -1285,23 +1285,6 @@ public class SearchActivityInstanceIT extends TestWithUser {
                 TestConnectorLongToExecute.class, "TestConnectorLongToExecute.jar");
     }
 
-
-    @Test
-    public void should_search_escape_special_chars() throws Exception {
-        final ProcessDefinitionBuilder definitionBuilder = new ProcessDefinitionBuilder().createNewInstance(PROCESS_NAME + "12", PROCESS_VERSION + "1");
-        definitionBuilder.addUserTask("d'stàp","actor");
-        definitionBuilder.addActor("actor");
-        final ProcessDefinition processDefinition = deployAndEnableProcessWithActor(definitionBuilder.done(), "actor", user);
-
-        getProcessAPI().startProcess(processDefinition.getId());
-        waitForUserTask("d'stàp");
-
-        final SearchResult<FlowNodeInstance> result = getProcessAPI().searchFlowNodeInstances(new SearchOptionsBuilder(0, 10).filter("name", "d'stàp").done());
-
-        assertThat(result.getResult()).hasSize(1);
-        disableAndDeleteProcess(processDefinition);
-
-    }
     @Test
     public void should_search_prevent_injection() throws Exception {
 

--- a/services/bonita-persistence/bonita-persistence-db/src/main/java/org/bonitasoft/engine/persistence/AbstractDBPersistenceService.java
+++ b/services/bonita-persistence/bonita-persistence-db/src/main/java/org/bonitasoft/engine/persistence/AbstractDBPersistenceService.java
@@ -13,18 +13,13 @@
  **/
 package org.bonitasoft.engine.persistence;
 
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-
 import javax.sql.DataSource;
 
 import org.bonitasoft.engine.commons.ClassReflector;
@@ -224,9 +219,8 @@ public abstract class AbstractDBPersistenceService implements TenantPersistenceS
                 + getLikeEscapeCharacter() + "'";
     }
 
-    /**
-     * @param term
-     * @return
+    /*
+     *  escape for like
      */
     protected String escapeTerm(final String term) {
         // 1) escape ' character by adding another ' character
@@ -238,6 +232,14 @@ public abstract class AbstractDBPersistenceService implements TenantPersistenceS
                 .replaceAll(getLikeEscapeCharacter(), getLikeEscapeCharacter() + getLikeEscapeCharacter())
                 .replaceAll("%", getLikeEscapeCharacter() + "%")
                 .replaceAll("_", getLikeEscapeCharacter() + "_");
+    }
+    /*
+     *  escape for other things than like
+     */
+    protected String escapeString(final String term) {
+        // 1) escape ' character by adding another ' character
+        return term
+                .replaceAll("'", "''");
     }
 
     protected String getLikeEscapeCharacter() {

--- a/services/bonita-persistence/bonita-persistence-db/src/test/java/org/bonitasoft/engine/persistence/AbstractDBPersistenceServiceTest.java
+++ b/services/bonita-persistence/bonita-persistence-db/src/test/java/org/bonitasoft/engine/persistence/AbstractDBPersistenceServiceTest.java
@@ -16,12 +16,10 @@ package org.bonitasoft.engine.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.sql.DataSource;
 
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
@@ -280,5 +278,6 @@ public class AbstractDBPersistenceServiceTest {
 
         assertThat(persistenceService.isWordSearchEnabled(entityClass)).isEqualTo(expectedResult);
     }
+
 
 }

--- a/services/bonita-persistence/bonita-persistence-hibernate/src/main/java/org/bonitasoft/engine/persistence/AbstractHibernatePersistenceService.java
+++ b/services/bonita-persistence/bonita-persistence-hibernate/src/main/java/org/bonitasoft/engine/persistence/AbstractHibernatePersistenceService.java
@@ -471,9 +471,7 @@ public abstract class AbstractHibernatePersistenceService extends AbstractDBPers
         for (final Entry<Class<? extends PersistentObject>, Set<String>> entry : allTextFields.entrySet()) {
             final String alias = getClassAliasMappings().get(entry.getKey().getName());
             for (final String field : entry.getValue()) {
-                final StringBuilder aliasBuilder = new StringBuilder(alias);
-                aliasBuilder.append('.').append(field);
-                fields.add(aliasBuilder.toString());
+                fields.add(alias + '.' + field);
             }
         }
         fields.removeAll(specificFilters);
@@ -556,7 +554,7 @@ public abstract class AbstractHibernatePersistenceService extends AbstractDBPers
         }
         Object fieldValue = filterOption.getValue();
         if (fieldValue instanceof String) {
-            fieldValue = "'" + fieldValue + "'";
+            fieldValue = "'" + escapeString((String) fieldValue) + "'";
         } else if (fieldValue instanceof EnumToObjectConvertible) {
             fieldValue = ((EnumToObjectConvertible) fieldValue).fromEnum();
         }
@@ -587,14 +585,14 @@ public abstract class AbstractHibernatePersistenceService extends AbstractDBPers
                 clause.append(getInClause(completeField, filterOption));
                 break;
             case BETWEEN:
-                final Object from = filterOption.getFrom() instanceof String ? "'" + filterOption.getFrom() + "'" : filterOption.getFrom();
-                final Object to = filterOption.getTo() instanceof String ? "'" + filterOption.getTo() + "'" : filterOption.getTo();
+                final Object from = filterOption.getFrom() instanceof String ? "'" + escapeString((String) filterOption.getFrom()) + "'" : filterOption.getFrom();
+                final Object to = filterOption.getTo() instanceof String ? "'" + escapeString((String) filterOption.getTo()) + "'" : filterOption.getTo();
                 clause.append("(").append(from).append(" <= ").append(completeField);
                 clause.append(" AND ").append(completeField).append(" <= ").append(to).append(")");
                 break;
             case LIKE:
                 // TODO:write LIKE
-                clause.append(completeField).append(" LIKE '%").append(filterOption.getValue()).append("%'");
+                clause.append(completeField).append(" LIKE '%").append(escapeTerm((String) filterOption.getValue())).append("%'");
                 break;
             case L_PARENTHESIS:
                 clause.append(" (");

--- a/services/bonita-persistence/bonita-persistence-hibernate/src/test/java/org/bonitasoft/engine/persistence/AbstractHibernatePersistenceServiceTest.java
+++ b/services/bonita-persistence/bonita-persistence-hibernate/src/test/java/org/bonitasoft/engine/persistence/AbstractHibernatePersistenceServiceTest.java
@@ -59,4 +59,18 @@ public class AbstractHibernatePersistenceServiceTest {
         assertThat(queryBuilder.toString()).contains("LIKE 'foo%'").doesNotContain("LIKE '% foo%'");
     }
 
+    @Test
+    public void should_escapeString_escape_quote(){
+        doCallRealMethod().when(persistenceService).escapeString(anyString());
+        final String s = persistenceService.escapeString("toto'toto");
+
+        assertThat(s).isEqualTo("toto''toto");
+    }
+    @Test
+    public void should_escapeString_do_not_escape_like_wildcard(){
+        doCallRealMethod().when(persistenceService).escapeString(anyString());
+        final String s = persistenceService.escapeString("%to'to%t_oto%");
+
+        assertThat(s).isEqualTo("%to''to%t_oto%");
+    }
 }


### PR DESCRIPTION
escape quotes in search in order to prevent injection + work with name having quotes

wanted to replace hql query generation by generating hibernate parameters but it was breaking the filters with e.g. long that were given as string
so only replaced quotes in the search term