### PR TITLE
Inject the tenantId directly from Spring bean

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-local/src/test/java/org/bonitasoft/engine/cache/CacheServiceTest.java
+++ b/bonita-integration-tests/bonita-integration-tests-local/src/test/java/org/bonitasoft/engine/cache/CacheServiceTest.java
@@ -71,7 +71,7 @@ public class CacheServiceTest {
     }
 
     protected CacheService getCacheService() {
-        final List<CacheConfiguration> configurationsList = new ArrayList<CacheConfiguration>(2);
+        final List<CacheConfiguration> configurationsList = new ArrayList<>(2);
         final CacheConfiguration cacheConfiguration = new CacheConfiguration();
         cacheConfiguration.setName(SOME_DEFAULT_CACHE_NAME);
         cacheConfiguration.setTimeToLiveSeconds(1);
@@ -140,7 +140,7 @@ public class CacheServiceTest {
             public long getSessionId() {
                 return 1;
             }
-        }, configurationsList, new CacheConfiguration(), "target");
+        }, configurationsList, new CacheConfiguration(), "target", 1);
     }
 
 	private CacheConfiguration createOneElementInMemoryCacheConfiguration() {
@@ -224,8 +224,8 @@ public class CacheServiceTest {
     @Test
     public void testPutComplexObjectInCache() throws SCacheException {
         final int cacheSize = cacheService.getCacheSize(TEST1);
-        final ArrayList<Map<String, String>> list = new ArrayList<Map<String, String>>();
-        final HashMap<String, String> map = new HashMap<String, String>();
+        final ArrayList<Map<String, String>> list = new ArrayList<>();
+        final HashMap<String, String> map = new HashMap<>();
         map.put("bpm", "bonita");
         list.add(map);
         cacheService.store(TEST1, "complex", list);
@@ -235,8 +235,8 @@ public class CacheServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testGetComplexObjectInCache() throws SCacheException {
-        final ArrayList<Map<String, String>> list = new ArrayList<Map<String, String>>();
-        final HashMap<String, String> map = new HashMap<String, String>();
+        final ArrayList<Map<String, String>> list = new ArrayList<>();
+        final HashMap<String, String> map = new HashMap<>();
         map.put("bpm", "bonita");
         list.add(map);
         cacheService.store(TEST1, "complex", list);
@@ -327,7 +327,7 @@ public class CacheServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testChangeCachedElementWithCopy() throws SCacheException {
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         cacheService.store(TEST1, "mylist", list);
         list.add("kikoo");
         final ArrayList<String> cachedList = (ArrayList<String>) cacheService.get(TEST1, "mylist");
@@ -337,7 +337,7 @@ public class CacheServiceTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testChangeCachedElementWithoutCopy() throws SCacheException {
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         cacheService.store(TEST2, "mylist", list);
         list.add("kikoo");
         final ArrayList<String> cachedList = (ArrayList<String>) cacheService.get(TEST2, "mylist");

--- a/bonita-integration-tests/bonita-integration-tests-local/src/test/java/org/bonitasoft/engine/cache/CacheServiceTest.java
+++ b/bonita-integration-tests/bonita-integration-tests-local/src/test/java/org/bonitasoft/engine/cache/CacheServiceTest.java
@@ -28,7 +28,6 @@ import org.bonitasoft.engine.cache.ehcache.EhCacheCacheService;
 import org.bonitasoft.engine.commons.exceptions.SBonitaException;
 import org.bonitasoft.engine.log.technical.TechnicalLogSeverity;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
-import org.bonitasoft.engine.sessionaccessor.ReadSessionAccessor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -128,17 +127,6 @@ public class CacheServiceTest {
             @Override
             public boolean isLoggable(final Class<?> callerClass, final TechnicalLogSeverity severity) {
                 return false;
-            }
-        }, new ReadSessionAccessor() {
-
-            @Override
-            public long getTenantId() {
-                return 1;
-            }
-
-            @Override
-            public long getSessionId() {
-                return 1;
             }
         }, configurationsList, new CacheConfiguration(), "target", 1);
     }

--- a/bpm/bonita-home/src/main/resources/bonita-platform-community.xml
+++ b/bpm/bonita-home/src/main/resources/bonita-platform-community.xml
@@ -233,7 +233,6 @@
 
     <bean id="platformCacheService" class="org.bonitasoft.engine.cache.ehcache.PlatformEhCacheCacheService">
         <constructor-arg name="logger" ref="platformTechnicalLoggerService" />
-        <constructor-arg name="sessionAccessor" ref="sessionAccessor" />
         <constructor-arg name="cacheConfigurations" ref="platformCacheConfigurations" />
         <constructor-arg name="defaultCacheConfiguration" ref="defaultPlatformCacheConfiguration" />
         <constructor-arg name="diskStorePath" value="java.io.tmpdir/platform.cache" />

--- a/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
+++ b/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
@@ -1351,6 +1351,7 @@
         <constructor-arg name="cacheConfigurations" ref="cacheConfigurations" />
         <constructor-arg name="defaultCacheConfiguration" ref="defaultTenantCacheConfiguration" />
         <constructor-arg name="diskStorePath" value="java.io.tmpdir/tenant.cache" />
+        <constructor-arg name="tenantId" value="${tenantId}" />
     </bean>
 
     <bean id="defaultTenantCacheConfiguration" class="org.bonitasoft.engine.cache.CacheConfiguration">

--- a/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
+++ b/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
@@ -1347,7 +1347,6 @@
 
     <bean id="cacheService" class="org.bonitasoft.engine.cache.ehcache.EhCacheCacheService">
         <constructor-arg name="logger" ref="tenantTechnicalLoggerService" />
-        <constructor-arg name="sessionAccessor" ref="sessionAccessor" />
         <constructor-arg name="cacheConfigurations" ref="cacheConfigurations" />
         <constructor-arg name="defaultCacheConfiguration" ref="defaultTenantCacheConfiguration" />
         <constructor-arg name="diskStorePath" value="java.io.tmpdir/tenant.cache" />

--- a/services/bonita-cache/bonita-cache-ehcache/src/main/java/org/bonitasoft/engine/cache/ehcache/EhCacheCacheService.java
+++ b/services/bonita-cache/bonita-cache-ehcache/src/main/java/org/bonitasoft/engine/cache/ehcache/EhCacheCacheService.java
@@ -22,7 +22,6 @@ import org.bonitasoft.engine.cache.CacheService;
 import org.bonitasoft.engine.cache.SCacheException;
 import org.bonitasoft.engine.commons.exceptions.SBonitaRuntimeException;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
-import org.bonitasoft.engine.sessionaccessor.ReadSessionAccessor;
 
 /**
  * @author Baptiste Mesta
@@ -33,15 +32,15 @@ public class EhCacheCacheService extends CommonEhCacheCacheService implements Ca
 
     private final long tenantId;
 
-    public EhCacheCacheService(final TechnicalLoggerService logger, final ReadSessionAccessor sessionAccessor,
-            final List<CacheConfiguration> cacheConfigurations, final CacheConfiguration defaultCacheConfiguration, final String diskStorePath, long tenantId) {
-        super(logger, sessionAccessor, cacheConfigurations, defaultCacheConfiguration, diskStorePath);
+    public EhCacheCacheService(final TechnicalLoggerService logger, final List<CacheConfiguration> cacheConfigurations,
+            final CacheConfiguration defaultCacheConfiguration, final String diskStorePath, long tenantId) {
+        super(logger, cacheConfigurations, defaultCacheConfiguration, diskStorePath);
         this.tenantId = tenantId;
     }
 
     @Override
     protected String getKeyFromCacheName(final String cacheName) throws SCacheException {
-        return new StringBuilder().append(tenantId).append('_').append(cacheName).toString();
+        return String.valueOf(tenantId) + '_' + cacheName;
     }
 
     @Override
@@ -51,7 +50,7 @@ public class EhCacheCacheService extends CommonEhCacheCacheService implements Ca
         }
         final String[] cacheNames = cacheManager.getCacheNames();
         final List<String> cacheNamesList = new ArrayList<>(cacheNames.length);
-        String prefix = new StringBuilder().append(tenantId).append('_').toString();
+        String prefix = String.valueOf(tenantId) + '_';
         for (final String cacheName : cacheNames) {
             if (cacheName.startsWith(prefix)) {
                 cacheNamesList.add(getCacheNameFromKey(cacheName));
@@ -90,4 +89,8 @@ public class EhCacheCacheService extends CommonEhCacheCacheService implements Ca
         }
     }
 
+    @Override
+    protected String getCacheManagerIdentifier() {
+        return "tenant " + tenantId;
+    }
 }

--- a/services/bonita-cache/bonita-cache-ehcache/src/main/java/org/bonitasoft/engine/cache/ehcache/EhCacheCacheService.java
+++ b/services/bonita-cache/bonita-cache-ehcache/src/main/java/org/bonitasoft/engine/cache/ehcache/EhCacheCacheService.java
@@ -23,7 +23,6 @@ import org.bonitasoft.engine.cache.SCacheException;
 import org.bonitasoft.engine.commons.exceptions.SBonitaRuntimeException;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
 import org.bonitasoft.engine.sessionaccessor.ReadSessionAccessor;
-import org.bonitasoft.engine.sessionaccessor.STenantIdNotSetException;
 
 /**
  * @author Baptiste Mesta
@@ -32,18 +31,17 @@ import org.bonitasoft.engine.sessionaccessor.STenantIdNotSetException;
  */
 public class EhCacheCacheService extends CommonEhCacheCacheService implements CacheService {
 
-    public EhCacheCacheService(final TechnicalLoggerService logger, final ReadSessionAccessor sessionAccessor, final List<CacheConfiguration> cacheConfigurations,
-            final CacheConfiguration defaultCacheConfiguration, final String diskStorePath) {
+    private final long tenantId;
+
+    public EhCacheCacheService(final TechnicalLoggerService logger, final ReadSessionAccessor sessionAccessor,
+            final List<CacheConfiguration> cacheConfigurations, final CacheConfiguration defaultCacheConfiguration, final String diskStorePath, long tenantId) {
         super(logger, sessionAccessor, cacheConfigurations, defaultCacheConfiguration, diskStorePath);
+        this.tenantId = tenantId;
     }
 
     @Override
     protected String getKeyFromCacheName(final String cacheName) throws SCacheException {
-        try {
-            return String.valueOf(sessionAccessor.getTenantId()) + '_' + cacheName;
-        } catch (final STenantIdNotSetException e) {
-            throw new SCacheException(e);
-        }
+        return new StringBuilder().append(tenantId).append('_').append(cacheName).toString();
     }
 
     @Override
@@ -52,17 +50,12 @@ public class EhCacheCacheService extends CommonEhCacheCacheService implements Ca
             return Collections.emptyList();
         }
         final String[] cacheNames = cacheManager.getCacheNames();
-        final List<String> cacheNamesList = new ArrayList<String>(cacheNames.length);
-        String prefix;
-        try {
-            prefix = String.valueOf(sessionAccessor.getTenantId()) + '_';
-            for (final String cacheName : cacheNames) {
-                if (cacheName.startsWith(prefix)) {
-                    cacheNamesList.add(getCacheNameFromKey(cacheName));
-                }
+        final List<String> cacheNamesList = new ArrayList<>(cacheNames.length);
+        String prefix = new StringBuilder().append(tenantId).append('_').toString();
+        for (final String cacheName : cacheNames) {
+            if (cacheName.startsWith(prefix)) {
+                cacheNamesList.add(getCacheNameFromKey(cacheName));
             }
-        } catch (final STenantIdNotSetException e) {
-            throw new RuntimeException(e);
         }
         return cacheNamesList;
     }

--- a/services/bonita-cache/bonita-cache-ehcache/src/main/java/org/bonitasoft/engine/cache/ehcache/PlatformEhCacheCacheService.java
+++ b/services/bonita-cache/bonita-cache-ehcache/src/main/java/org/bonitasoft/engine/cache/ehcache/PlatformEhCacheCacheService.java
@@ -21,7 +21,6 @@ import org.bonitasoft.engine.cache.PlatformCacheService;
 import org.bonitasoft.engine.cache.SCacheException;
 import org.bonitasoft.engine.commons.exceptions.SBonitaRuntimeException;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
-import org.bonitasoft.engine.sessionaccessor.ReadSessionAccessor;
 
 /**
  * Platform version of the EhCacheCacheService
@@ -30,9 +29,9 @@ import org.bonitasoft.engine.sessionaccessor.ReadSessionAccessor;
  */
 public class PlatformEhCacheCacheService extends CommonEhCacheCacheService implements PlatformCacheService {
 
-    public PlatformEhCacheCacheService(final TechnicalLoggerService logger, final ReadSessionAccessor sessionAccessor,
-            final List<CacheConfiguration> cacheConfigurations, final CacheConfiguration defaultCacheConfiguration, final String diskStorePath) {
-        super(logger, sessionAccessor, cacheConfigurations, defaultCacheConfiguration, diskStorePath);
+    public PlatformEhCacheCacheService(final TechnicalLoggerService logger, final List<CacheConfiguration> cacheConfigurations,
+            final CacheConfiguration defaultCacheConfiguration, final String diskStorePath) {
+        super(logger, cacheConfigurations, defaultCacheConfiguration, diskStorePath);
     }
 
     @Override
@@ -43,7 +42,7 @@ public class PlatformEhCacheCacheService extends CommonEhCacheCacheService imple
     @Override
     public List<String> getCachesNames() {
         final String[] cacheNames = cacheManager.getCacheNames();
-        final List<String> cacheNamesList = new ArrayList<String>(cacheNames.length);
+        final List<String> cacheNamesList = new ArrayList<>(cacheNames.length);
         final String prefix = "P_";
         for (final String cacheName : cacheNames) {
             if (cacheName.startsWith(prefix)) {
@@ -83,4 +82,8 @@ public class PlatformEhCacheCacheService extends CommonEhCacheCacheService imple
         }
     }
 
+    @Override
+    protected String getCacheManagerIdentifier() {
+        return "platform";
+    }
 }

--- a/services/bonita-cache/bonita-cache-ehcache/src/test/java/org/bonitasoft/engine/cache/ehcache/CommonEhCacheCacheServiceTest.java
+++ b/services/bonita-cache/bonita-cache-ehcache/src/test/java/org/bonitasoft/engine/cache/ehcache/CommonEhCacheCacheServiceTest.java
@@ -54,7 +54,7 @@ public class CommonEhCacheCacheServiceTest {
 
     @Before
     public void setup() {
-        cacheService = new EhCacheCacheService(logger, sessionAccessor, cacheConfigurations, defaultCacheConfiguration, null) {
+        cacheService = new EhCacheCacheService(logger, sessionAccessor, cacheConfigurations, defaultCacheConfiguration, null, 1) {
 
             @Override
             public synchronized void start() {

--- a/services/bonita-cache/bonita-cache-ehcache/src/test/java/org/bonitasoft/engine/cache/ehcache/CommonEhCacheCacheServiceTest.java
+++ b/services/bonita-cache/bonita-cache-ehcache/src/test/java/org/bonitasoft/engine/cache/ehcache/CommonEhCacheCacheServiceTest.java
@@ -54,7 +54,7 @@ public class CommonEhCacheCacheServiceTest {
 
     @Before
     public void setup() {
-        cacheService = new EhCacheCacheService(logger, sessionAccessor, cacheConfigurations, defaultCacheConfiguration, null, 1) {
+        cacheService = new EhCacheCacheService(logger, cacheConfigurations, defaultCacheConfiguration, null, 1) {
 
             @Override
             public synchronized void start() {

--- a/services/bonita-expression/bonita-expression-api-impl/src/test/java/org/bonitasoft/engine/expression/impl/GroovyScriptExpressionExecutorCacheStrategyTest.java
+++ b/services/bonita-expression/bonita-expression-api-impl/src/test/java/org/bonitasoft/engine/expression/impl/GroovyScriptExpressionExecutorCacheStrategyTest.java
@@ -77,7 +77,7 @@ public class GroovyScriptExpressionExecutorCacheStrategyTest {
         final CacheConfiguration cacheConfiguration = new CacheConfiguration();
         cacheConfiguration.setName("GROOVY_SCRIPT_CACHE_NAME");
         final List<CacheConfiguration> cacheConfigurations = Arrays.asList(cacheConfiguration);
-        cacheService = new EhCacheCacheService(logger, sessionAccessor, cacheConfigurations, defaultCacheConfiguration, diskStorePath);
+        cacheService = new EhCacheCacheService(logger, sessionAccessor, cacheConfigurations, defaultCacheConfiguration, diskStorePath, 1);
         cacheService.start();
         groovyScriptExpressionExecutorCacheStrategy = new GroovyScriptExpressionExecutorCacheStrategy(cacheService, classLoaderService, logger);
         doReturn(GroovyScriptExpressionExecutorCacheStrategyTest.class.getClassLoader()).when(classLoaderService).getLocalClassLoader(anyString(), anyLong());

--- a/services/bonita-expression/bonita-expression-api-impl/src/test/java/org/bonitasoft/engine/expression/impl/GroovyScriptExpressionExecutorCacheStrategyTest.java
+++ b/services/bonita-expression/bonita-expression-api-impl/src/test/java/org/bonitasoft/engine/expression/impl/GroovyScriptExpressionExecutorCacheStrategyTest.java
@@ -77,7 +77,7 @@ public class GroovyScriptExpressionExecutorCacheStrategyTest {
         final CacheConfiguration cacheConfiguration = new CacheConfiguration();
         cacheConfiguration.setName("GROOVY_SCRIPT_CACHE_NAME");
         final List<CacheConfiguration> cacheConfigurations = Arrays.asList(cacheConfiguration);
-        cacheService = new EhCacheCacheService(logger, sessionAccessor, cacheConfigurations, defaultCacheConfiguration, diskStorePath, 1);
+        cacheService = new EhCacheCacheService(logger,  cacheConfigurations, defaultCacheConfiguration, diskStorePath, 1);
         cacheService.start();
         groovyScriptExpressionExecutorCacheStrategy = new GroovyScriptExpressionExecutorCacheStrategy(cacheService, classLoaderService, logger);
         doReturn(GroovyScriptExpressionExecutorCacheStrategyTest.class.getClassLoader()).when(classLoaderService).getLocalClassLoader(anyString(), anyLong());


### PR DESCRIPTION
Instead of retrieve the tenant id from the SessionAccessor, use directly the value injected by Spring in the bonita.home. This avoid exceptions in the case of the tenant id is not set in the session accessor.