### PR TITLE
Feat/groovy executor register listeners

### DIFF
--- a/services/bonita-expression/bonita-expression-api-impl/src/test/java/org/bonitasoft/engine/expression/impl/GroovyScriptExpressionExecutorCacheStrategyTest.java
+++ b/services/bonita-expression/bonita-expression-api-impl/src/test/java/org/bonitasoft/engine/expression/impl/GroovyScriptExpressionExecutorCacheStrategyTest.java
@@ -109,6 +109,39 @@ public class GroovyScriptExpressionExecutorCacheStrategyTest {
         assertThat(shell1).isNotEqualTo(shell2);
     }
 
+
+    @Test
+    public void should_update_on_classloader_listener_clear_shell_cache() throws Exception {
+        // given
+
+        // when
+        final GroovyShell shell1 = groovyScriptExpressionExecutorCacheStrategy.getShell(12l);
+        groovyScriptExpressionExecutorCacheStrategy.onUpdate(null);
+        final GroovyShell shell2 = groovyScriptExpressionExecutorCacheStrategy.getShell(12l);
+
+        // then
+        assertThat(shell1).isNotNull();
+        assertThat(shell2).isNotNull();
+        assertThat(shell1).isNotEqualTo(shell2);
+    }
+
+
+    @Test
+    public void should_destroy_on_classloader_listener_clear_shell_cache() throws Exception {
+        // given
+
+        // when
+        final GroovyShell shell1 = groovyScriptExpressionExecutorCacheStrategy.getShell(12l);
+        groovyScriptExpressionExecutorCacheStrategy.onDestroy(null);
+        final GroovyShell shell2 = groovyScriptExpressionExecutorCacheStrategy.getShell(12l);
+
+        // then
+        assertThat(shell1).isNotNull();
+        assertThat(shell2).isNotNull();
+        assertThat(shell1).isNotEqualTo(shell2);
+    }
+
+
     @Test
     public void should_getShell_return_same_shell_for_1_definition() throws Exception {
         // when


### PR DESCRIPTION
fix classloader issue and leak on groovy exec …
the groovy shell were kept even if the classloader were destroy/updated
also this was causing script executed there to not have the updated
classloader

added the listener when creating a new shell in order to clear the cache
in this case

we do not need to remove the listeners because after destroy the virtual
classloader will be GCed and we can't add 2 times the same listener on
the same virtual classloader

Finally forbid to have a shell on a non process classloader

depends on https://github.com/bonitasoft/bonita-engine/pull/209

