### PR TITLE
add global listeners + listener on classreflector

### DIFF
--- a/services/bonita-classloader/bonita-classloader-api/src/main/java/org/bonitasoft/engine/classloader/ClassLoaderService.java
+++ b/services/bonita-classloader/bonita-classloader-api/src/main/java/org/bonitasoft/engine/classloader/ClassLoaderService.java
@@ -26,23 +26,22 @@ public interface ClassLoaderService extends PlatformLifecycleService {
 
     /**
      * Get the global ClassLoader. If no global ClassLoader already exists, create it.
-     * 
+     *
      * @return the global ClassLoader
-     * @throws SClassLoaderException
-     *         Error thrown if it's impossible to get the global ClassLoader
+     * @throws SClassLoaderException Error thrown if it's impossible to get the global ClassLoader
      */
     ClassLoader getGlobalClassLoader() throws SClassLoaderException;
 
     /**
      * Get type of global class loader
-     * 
+     *
      * @return type of global class loader
      */
     String getGlobalClassLoaderType();
 
     /**
      * Get id of global class loader
-     * 
+     *
      * @return id of global class loader
      */
     long getGlobalClassLoaderId();
@@ -50,24 +49,19 @@ public interface ClassLoaderService extends PlatformLifecycleService {
     /**
      * Get the local ClassLoader for the given type and id. If no ClassLoader is associated to them,
      * a new one is created.
-     * 
-     * @param type
-     *        The classloader's type identifier
-     * @param id
-     *        The local ClassLoader's id
+     *
+     * @param type The classloader's type identifier
+     * @param id   The local ClassLoader's id
      * @return the local ClassLoader for the given type and id
-     * @throws SClassLoaderException
-     *         Error thrown if it's impossible to get a local ClassLoader for the given type and id
+     * @throws SClassLoaderException Error thrown if it's impossible to get a local ClassLoader for the given type and id
      */
     ClassLoader getLocalClassLoader(final String type, final long id) throws SClassLoaderException;
 
     /**
      * Remove the local ClassLoader identified by the given type and id;
-     * 
-     * @param type
-     *        The classloader's type identifier
-     * @param id
-     *        The local ClassLoader's id
+     *
+     * @param type The classloader's type identifier
+     * @param id   The local ClassLoader's id
      * @throws SClassLoaderException if we can't remove the classloader because it contains children
      */
     void removeLocalClassLoader(final String type, final long id) throws SClassLoaderException;
@@ -76,7 +70,37 @@ public interface ClassLoaderService extends PlatformLifecycleService {
 
     void refreshLocalClassLoader(final String type, final long id, final Map<String, byte[]> resources) throws SClassLoaderException;
 
+    /**
+     * add listener on a classloader
+     *
+     * @param type                the classloader type
+     * @param id                  the classloader id
+     * @param classLoaderListener the listener to add
+     * @return true if the listener was added
+     */
     boolean addListener(final String type, final long id, ClassLoaderListener classLoaderListener);
 
+    /**
+     * @param type                the classloader type
+     * @param id                  the classloader id
+     * @param classLoaderListener classloader listener to remove
+     * @return true if the listener was removed
+     */
     boolean removeListener(String type, long id, ClassLoaderListener classLoaderListener);
+
+    /**
+     * add a listener that will listen all classloader events
+     *
+     * @param classLoaderListener the listener to add
+     * @return true if the listener was added
+     */
+    boolean addListener(ClassLoaderListener classLoaderListener);
+
+    /**
+     * remove a global listener
+     *
+     * @param classLoaderListener classloader listener to remove
+     * @return true if the listener was removed
+     */
+    boolean removeListener(ClassLoaderListener classLoaderListener);
 }

--- a/services/bonita-classloader/bonita-classloader-impl/src/main/java/org/bonitasoft/engine/classloader/listeners/ClassReflectorClearer.java
+++ b/services/bonita-classloader/bonita-classloader-impl/src/main/java/org/bonitasoft/engine/classloader/listeners/ClassReflectorClearer.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.classloader.listeners;
+
+import org.bonitasoft.engine.classloader.ClassLoaderListener;
+import org.bonitasoft.engine.commons.ClassReflector;
+
+/**
+ * @author Baptiste Mesta
+ */
+public class ClassReflectorClearer implements ClassLoaderListener {
+    @Override
+    public void onUpdate(ClassLoader newClassLoader) {
+        ClassReflector.clearCache();
+    }
+
+    @Override
+    public void onDestroy(ClassLoader oldClassLoader) {
+        ClassReflector.clearCache();
+    }
+}

--- a/services/bonita-classloader/bonita-classloader-impl/src/test/java/org/bonitasoft/engine/classloader/ClassLoaderServiceImplTest.java
+++ b/services/bonita-classloader/bonita-classloader-impl/src/test/java/org/bonitasoft/engine/classloader/ClassLoaderServiceImplTest.java
@@ -1,10 +1,14 @@
 package org.bonitasoft.engine.classloader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.util.Collections;
@@ -208,5 +212,33 @@ public class ClassLoaderServiceImplTest {
 
     }
 
+
+    @Test
+    public void should_globalListeners_be_called_on_destroy() throws Exception {
+        //given
+        classLoaderService.getLocalClassLoader(CHILD_TYPE, 17);//second classloader
+        ClassLoaderListener listener = mock(ClassLoaderListener.class);
+        classLoaderService.addListener(listener);
+        //when
+        classLoaderService.removeLocalClassLoader(CHILD_TYPE, CHILD_ID);
+        classLoaderService.removeLocalClassLoader(CHILD_TYPE, 17);
+
+        //then
+        verify(listener, times(2)).onDestroy(any(VirtualClassLoader.class));
+    }
+
+    @Test
+    public void should_globalListeners_be_called_on_update() throws Exception {
+        //given
+        classLoaderService.getLocalClassLoader(CHILD_TYPE, 17);//second classloader
+        ClassLoaderListener listener = mock(ClassLoaderListener.class);
+        classLoaderService.addListener(listener);
+        //when
+        classLoaderService.refreshLocalClassLoader(CHILD_TYPE, CHILD_ID, Collections.<String, byte[]>emptyMap());
+        classLoaderService.refreshLocalClassLoader(CHILD_TYPE, 17, Collections.<String, byte[]>emptyMap());
+
+        //then
+        verify(listener, times(2)).onUpdate(any(VirtualClassLoader.class));
+    }
 
 }

--- a/services/bonita-classloader/bonita-classloader-impl/src/test/java/org/bonitasoft/engine/classloader/listeners/ClassReflectorClearerTest.java
+++ b/services/bonita-classloader/bonita-classloader-impl/src/test/java/org/bonitasoft/engine/classloader/listeners/ClassReflectorClearerTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * This library is free software; you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation
+ * version 2.1 of the License.
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+ * Floor, Boston, MA 02110-1301, USA.
+ **/
+
+package org.bonitasoft.engine.classloader.listeners;
+
+import org.assertj.core.api.Assertions;
+import org.bonitasoft.engine.commons.ClassReflector;
+import org.junit.Test;
+
+/**
+ * @author Baptiste Mesta
+ */
+public class ClassReflectorClearerTest {
+
+    @Test
+    public void testOnUpdate() throws Exception {
+        ClassReflector.getMethod(this.getClass(), "testOnUpdate");
+
+        Assertions.assertThat(ClassReflector.getCacheSize()).isGreaterThan(0);
+        new ClassReflectorClearer().onUpdate(null);
+        Assertions.assertThat(ClassReflector.getCacheSize()).isEqualTo(0);
+    }
+
+    @Test
+    public void testOnDestroy() throws Exception {
+        ClassReflector.getMethod(this.getClass(), "testOnUpdate");
+
+        Assertions.assertThat(ClassReflector.getCacheSize()).isGreaterThan(0);
+        new ClassReflectorClearer().onDestroy(null);
+        Assertions.assertThat(ClassReflector.getCacheSize()).isEqualTo(0);
+
+    }
+}

--- a/services/bonita-commons/src/main/java/org/bonitasoft/engine/commons/ClassReflector.java
+++ b/services/bonita-commons/src/main/java/org/bonitasoft/engine/commons/ClassReflector.java
@@ -51,7 +51,7 @@ public class ClassReflector {
     private static final Object MUTEX = new Object();
 
     public static Collection<Method> getAccessibleGetters(final Class<?> clazz) {
-        final Collection<Method> methods = new HashSet<Method>();
+        final Collection<Method> methods = new HashSet<>();
         for (final Method method : clazz.getMethods()) {
             if (isAGetterMethod(method)) {
                 methods.add(method);
@@ -254,10 +254,9 @@ public class ClassReflector {
     }
 
     public static Method[] getDeclaredSetters(final Class<?> clazz) {
-        final List<Method> setters = new ArrayList<Method>();
+        final List<Method> setters = new ArrayList<>();
         final Method[] methods = clazz.getDeclaredMethods();
-        for (int i = 0; i < methods.length; i++) {
-            final Method method = methods[i];
+        for (final Method method : methods) {
             if (isASetterMethod(method)) {
                 setters.add(method);
             }
@@ -266,7 +265,7 @@ public class ClassReflector {
     }
 
     public static Method[] getDeclaredGetters(final Class<?> clazz) {
-        final List<Method> getters = new ArrayList<Method>();
+        final List<Method> getters = new ArrayList<>();
         final Method[] methods = clazz.getDeclaredMethods();
         for (final Method method : methods) {
             if (isAGetterMethod(method)) {
@@ -322,7 +321,9 @@ public class ClassReflector {
      * call a setter by reflection
      * support pointed notation like pojo.child.name
      * @param object
+     *      object on with to call the setter
      * @param fieldName
+     *
      * @param parameterValue
      * @throws SReflectException
      */
@@ -334,9 +335,20 @@ public class ClassReflector {
         }
 
         invokeMethodByName(object, getSetterName(getters[i]), parameterValue);
+
     }
 
     private static String getSetterName(String getter) {
         return "set" + WordUtils.capitalize(getter);
     }
+
+    public static void clearCache(){
+        methods.clear();
+    }
+
+    public static int getCacheSize(){
+        return methods.size();
+    }
+
+
 }


### PR DESCRIPTION
add global listener in the classloader service add use it to clear cache
of classreflector
the listener is directly added in the classloader service because it was
the easier given that class reflector is inside the bonita-commons
module