### PR TITLE
Use global listeners to clear reference to classes

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
@@ -375,7 +375,6 @@ public class BDRepositoryIT extends CommonAPIIT {
         bo.addField(field);
         final BusinessObjectModel model = new BusinessObjectModel();
         model.addBusinessObject(bo);
-        final BusinessObjectModelConverter converter = new BusinessObjectModelConverter();
         return model;
     }
 

--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
@@ -1443,10 +1443,15 @@ public class BDRepositoryIT extends CommonAPIIT {
         parameters.put("queryParameters", (Serializable) queryParameters);
 
         // when
-        final BusinessDataQueryResult businessDataQueryResult = (BusinessDataQueryResult) getCommandAPI().execute("getBusinessDataByQueryCommand", parameters);
+        Serializable jsonResult = ((BusinessDataQueryResultImpl) getCommandAPI().execute("getBusinessDataByQueryCommand", parameters)).getJsonResults();
+        getCommandAPI().addDependency("temporaryDeps", new byte[]{0, 1});
+        //TypeFactory.defaultInstance().clearCache();
+        //new HeapDumper().dumpHeap("target/leak.hprof", true);
+        jsonResult = ((BusinessDataQueryResultImpl) getCommandAPI().execute("getBusinessDataByQueryCommand", parameters)).getJsonResults();
+
 
         // then
-        assertThatJson(businessDataQueryResult.getJsonResults()).as("should get employee").hasSameStructureAs(getJsonContent("findByFirstNameAndLastNameNewOrder.json"));
+        assertThatJson(jsonResult).as("should get employee").hasSameStructureAs(getJsonContent("findByFirstNameAndLastNameNewOrder.json"));
 
     }
 

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/XpathUpdateQueryOperationExecutorStrategy.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/XpathUpdateQueryOperationExecutorStrategy.java
@@ -77,8 +77,6 @@ public class XpathUpdateQueryOperationExecutorStrategy implements OperationExecu
             final String dataInstanceName = operation.getLeftOperand().getName();
             // should be a String because the data is an xml expression
             final String dataValue = (String) expressionContext.getInputValues().get(dataInstanceName);
-            final SExpressionContext sExpressionContext = new SExpressionContext();
-            sExpressionContext.setInputValues(expressionContext.getInputValues());
             final Object variableValue = value;
 
             final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();

--- a/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/bpm/classloader/BonitaBPMParentClassLoaderResolverTest.java
+++ b/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/bpm/classloader/BonitaBPMParentClassLoaderResolverTest.java
@@ -47,7 +47,7 @@ public class BonitaBPMParentClassLoaderResolverTest {
         //when
         final ClassLoaderIdentifier parentClassLoaderIdentifier = bonitaBPMParentClassLoaderResolver.getParentClassLoaderIdentifier(childId);
         //then
-        assertThat(parentClassLoaderIdentifier).isNull();
+        assertThat(parentClassLoaderIdentifier).isEqualTo(ClassLoaderIdentifier.GLOBAL);
     }
 
     @Test
@@ -57,7 +57,7 @@ public class BonitaBPMParentClassLoaderResolverTest {
         //when
         final ClassLoaderIdentifier parentClassLoaderIdentifier = bonitaBPMParentClassLoaderResolver.getParentClassLoaderIdentifier(childId);
         //then
-        assertThat(parentClassLoaderIdentifier).isNull();
+        assertThat(parentClassLoaderIdentifier).isEqualTo(ClassLoaderIdentifier.GLOBAL);
     }
 
     @Test(expected = BonitaRuntimeException.class)

--- a/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
+++ b/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
@@ -1481,6 +1481,9 @@
                 <entry key="javax.persistence.validation.mode" value="${bonita.tenant.bdm.repository.javax.persistence.validation.mode}" />
             </map>
         </constructor-arg>
+        <constructor-arg name="loggerService" ref="tenantTechnicalLoggerService" />
+        <constructor-arg name="classLoaderService" ref="classLoaderService" />
+        <constructor-arg name="tenantId" value="${tenantId}" />
     </bean>
 
     <bean id="businessDataModelRepository"
@@ -1508,7 +1511,9 @@
     </bean>
 
     <bean id="jsonBusinessDataSerializer"
-          class="org.bonitasoft.engine.business.data.impl.JsonBusinessDataSerializerImpl" />
+          class="org.bonitasoft.engine.business.data.impl.JsonBusinessDataSerializerImpl" >
+        <constructor-arg name="classLoaderService" ref="classLoaderService" />
+    </bean>
 
     <bean id="typeConverterUtil" class="org.bonitasoft.engine.commons.TypeConverterUtil">
         <constructor-arg name="datePatterns" type="java.lang.String[]">

--- a/services/bonita-business-data/bonita-business-data-impl/pom.xml
+++ b/services/bonita-business-data/bonita-business-data-impl/pom.xml
@@ -58,6 +58,11 @@
 			<artifactId>bonita-commons</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+        <dependency>
+            <groupId>org.bonitasoft.engine.classloader</groupId>
+            <artifactId>bonita-classloader-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImpl.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImpl.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2015 BonitaSoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * Copyright (C) 2015 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
  * This library is free software; you can redistribute it and/or modify it under the terms
  * of the GNU Lesser General Public License as published by the Free Software Foundation
  * version 2.1 of the License.
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.NoResultException;
@@ -39,6 +38,11 @@ import org.bonitasoft.engine.business.data.BusinessDataModelRepository;
 import org.bonitasoft.engine.business.data.BusinessDataRepository;
 import org.bonitasoft.engine.business.data.NonUniqueResultException;
 import org.bonitasoft.engine.business.data.SBusinessDataNotFoundException;
+import org.bonitasoft.engine.classloader.ClassLoaderListener;
+import org.bonitasoft.engine.classloader.ClassLoaderService;
+import org.bonitasoft.engine.dependency.model.ScopeType;
+import org.bonitasoft.engine.log.technical.TechnicalLogSeverity;
+import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
 import org.bonitasoft.engine.transaction.STransactionNotFoundException;
 import org.bonitasoft.engine.transaction.TransactionService;
 import org.hibernate.Hibernate;
@@ -48,42 +52,82 @@ import org.hibernate.proxy.HibernateProxy;
  * @author Matthieu Chaffotte
  * @author Romain Bioteau
  */
-public class JPABusinessDataRepositoryImpl implements BusinessDataRepository {
+public class JPABusinessDataRepositoryImpl implements BusinessDataRepository, ClassLoaderListener {
 
     private static final String BDR_PERSISTENCE_UNIT = "BDR";
 
     private final Map<String, Object> configuration;
-
     private EntityManagerFactory entityManagerFactory;
-
-    private final ThreadLocal<EntityManager> managers = new ThreadLocal<EntityManager>();
-
+    private final ThreadLocal<EntityManager> managers = new ThreadLocal<>();
     private final BusinessDataModelRepository businessDataModelRepository;
+    private final TechnicalLoggerService loggerService;
+    private ClassLoaderService classLoaderService;
+    private final long tenantId;
 
     private final TransactionService transactionService;
 
-    public JPABusinessDataRepositoryImpl(final TransactionService transactionService, final BusinessDataModelRepository businessDataModelRepository,
-            final Map<String, Object> configuration) {
+    public JPABusinessDataRepositoryImpl(final TransactionService transactionService, final BusinessDataModelRepository businessDataModelRepository, TechnicalLoggerService loggerService,
+                                         final Map<String, Object> configuration, ClassLoaderService classLoaderService, long tenantId) {
         this.transactionService = transactionService;
         this.businessDataModelRepository = businessDataModelRepository;
-        this.configuration = new HashMap<String, Object>(configuration);
+        this.loggerService = loggerService;
+        this.classLoaderService = classLoaderService;
+        this.tenantId = tenantId;
+        this.configuration = new HashMap<>(configuration);
         this.configuration.put("hibernate.ejb.resource_scanner", InactiveScanner.class.getName());
     }
 
     @Override
     public void start() {
         if (businessDataModelRepository.isDBMDeployed()) {
-            entityManagerFactory = Persistence.createEntityManagerFactory(BDR_PERSISTENCE_UNIT, configuration);
+            loggerService.log(getClass(), TechnicalLogSeverity.DEBUG, "Create entity factory on tenant " + tenantId);
+            entityManagerFactory = createEntityManagerFactory();
         }
+        classLoaderService.addListener(ScopeType.TENANT.name(), tenantId, this);
+    }
+
+    EntityManagerFactory createEntityManagerFactory() {
+        return Persistence.createEntityManagerFactory(BDR_PERSISTENCE_UNIT, configuration);
     }
 
     @Override
     public void stop() {
-        if (entityManagerFactory != null) {
-            entityManagerFactory.close();
+        if (getEntityManagerFactory() != null) {
+            loggerService.log(getClass(), TechnicalLogSeverity.DEBUG, "Close entity factory because service is stopping on tenant " + tenantId);
+            getEntityManagerFactory().close();
             entityManagerFactory = null;
         }
+        classLoaderService.removeListener(ScopeType.TENANT.name(), tenantId, this);
     }
+
+    private synchronized void recreateEntityManagerFactory(ClassLoader newClassLoader) {
+        if (businessDataModelRepository.isDBMDeployed()) {
+            loggerService.log(getClass(), TechnicalLogSeverity.DEBUG, "Recreate entity factory for classloader " + newClassLoader + " on tenant " + tenantId);
+            ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(newClassLoader);
+                entityManagerFactory.close();
+                entityManagerFactory = createEntityManagerFactory();
+            } finally {
+                Thread.currentThread().setContextClassLoader(currentClassLoader);
+            }
+        }
+    }
+
+    public EntityManagerFactory getEntityManagerFactory() {
+        if (entityManagerFactory != null && !entityManagerFactory.isOpen()) {
+            /* If the entity manager is closed it means that the entity manager is currently reloading
+               In this case we get it inside a method synchronized with #recreateEntityManagerFactory
+             */
+            return synchronizedGetEntityManagerFactory();
+        }
+        return entityManagerFactory;
+    }
+
+    private synchronized EntityManagerFactory synchronizedGetEntityManagerFactory() {
+        return entityManagerFactory;
+    }
+
 
     @Override
     public void pause() {
@@ -97,12 +141,12 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository {
 
     @Override
     public Set<String> getEntityClassNames() {
-        if (entityManagerFactory == null) {
+        if (getEntityManagerFactory() == null) {
             return Collections.emptySet();
         }
         final EntityManager em = getEntityManager();
         final Set<EntityType<?>> entities = em.getMetamodel().getEntities();
-        final Set<String> entityClassNames = new HashSet<String>();
+        final Set<String> entityClassNames = new HashSet<>();
         for (final EntityType<?> entity : entities) {
             entityClassNames.add(entity.getJavaType().getName());
         }
@@ -110,17 +154,17 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository {
     }
 
     protected EntityManager getEntityManager() {
-        if (entityManagerFactory == null) {
+        if (getEntityManagerFactory() == null) {
             throw new IllegalStateException("The BDR is not started");
         }
 
         EntityManager manager = managers.get();
         if (manager == null || !manager.isOpen()) {
-            manager = entityManagerFactory.createEntityManager();
+            manager = getEntityManagerFactory().createEntityManager();
             try {
                 transactionService.registerBonitaSynchronization(new RemoveEntityManagerSynchronization(managers));
-            } catch (final STransactionNotFoundException stnfe) {
-                throw new IllegalStateException(stnfe);
+            } catch (final STransactionNotFoundException e) {
+                throw new IllegalStateException(e);
             }
             managers.set(manager);
         }
@@ -144,7 +188,7 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository {
     @Override
     public <T extends Entity> List<T> findByIds(final Class<T> entityClass, final List<Long> primaryKeys) {
         if (primaryKeys == null || primaryKeys.isEmpty()) {
-            return new ArrayList<T>();
+            return new ArrayList<>();
         }
         final EntityManager em = getEntityManager();
         final CriteriaBuilder cb = em.getCriteriaBuilder();
@@ -157,7 +201,7 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository {
     @Override
     public <T extends Entity> List<T> findByIdentifiers(final Class<T> entityClass, final List<Long> primaryKeys) {
         if (primaryKeys == null || primaryKeys.isEmpty()) {
-            return new ArrayList<T>();
+            return new ArrayList<>();
         }
         final List<T> entities = new ArrayList<>();
         for (final Long primaryKey : primaryKeys) {
@@ -198,7 +242,7 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository {
 
     @Override
     public <T extends Serializable> List<T> findList(final Class<T> resultClass, final String jpqlQuery, final Map<String, Serializable> parameters,
-            final int startIndex, final int maxResults) {
+                                                     final int startIndex, final int maxResults) {
         final TypedQuery<T> typedQuery = createTypedQuery(jpqlQuery, resultClass);
         return findList(typedQuery, parameters, startIndex, maxResults);
     }
@@ -213,7 +257,7 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository {
 
     @Override
     public <T extends Serializable> List<T> findListByNamedQuery(final String queryName, final Class<T> resultClass,
-            final Map<String, Serializable> parameters, final int startIndex, final int maxResults) {
+                                                                 final Map<String, Serializable> parameters, final int startIndex, final int maxResults) {
         final EntityManager em = getEntityManager();
         final TypedQuery<T> query = em.createNamedQuery(queryName, resultClass);
         return findList(query, parameters, startIndex, maxResults);
@@ -224,7 +268,7 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository {
     }
 
     protected <T extends Serializable> List<T> findList(final TypedQuery<T> query, final Map<String, Serializable> parameters, final int startIndex,
-            final int maxResults) {
+                                                        final int maxResults) {
         if (query == null) {
             throw new IllegalArgumentException("query is null");
         }
@@ -271,4 +315,13 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository {
         return entity;
     }
 
+    @Override
+    public void onUpdate(ClassLoader newClassLoader) {
+        recreateEntityManagerFactory(newClassLoader);
+    }
+
+    @Override
+    public void onDestroy(ClassLoader oldClassLoader) {
+
+    }
 }

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImpl.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImpl.java
@@ -17,24 +17,30 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
 
-import org.bonitasoft.engine.bdm.Entity;
-import org.bonitasoft.engine.business.data.JsonBusinessDataSerializer;
-import org.bonitasoft.engine.business.data.impl.utils.JsonNumberSerializerHelper;
-
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.bonitasoft.engine.bdm.Entity;
+import org.bonitasoft.engine.business.data.JsonBusinessDataSerializer;
+import org.bonitasoft.engine.business.data.impl.utils.JsonNumberSerializerHelper;
+import org.bonitasoft.engine.classloader.ClassLoaderListener;
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 
-public class JsonBusinessDataSerializerImpl implements JsonBusinessDataSerializer {
+public class JsonBusinessDataSerializerImpl implements JsonBusinessDataSerializer, ClassLoaderListener {
 
-    private final ObjectMapper mapper;
+    private ObjectMapper mapper;
 
-    private final EntitySerializer serializer;
+    private EntitySerializer serializer;
 
-    public JsonBusinessDataSerializerImpl() {
-        mapper = new ObjectMapper();
+    public JsonBusinessDataSerializerImpl(ClassLoaderService classLoaderService) {
+        init();
+        classLoaderService.addListener(this);
+    }
+
+    private void init() {
         serializer = new EntitySerializer(new JsonNumberSerializerHelper());
+        mapper = new ObjectMapper();
         final SimpleModule hbm = new SimpleModule();
         hbm.addSerializer(serializer);
         mapper.registerModule(hbm);
@@ -58,4 +64,13 @@ public class JsonBusinessDataSerializerImpl implements JsonBusinessDataSerialize
         return writer.toString();
     }
 
+    @Override
+    public void onUpdate(ClassLoader newClassLoader) {
+        init();
+    }
+
+    @Override
+    public void onDestroy(ClassLoader oldClassLoader) {
+        init();
+    }
 }

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/ConcurrencyIT.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/ConcurrencyIT.java
@@ -32,6 +32,7 @@ import javax.naming.Context;
 import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
 
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 import org.bonitasoft.engine.dependency.DependencyService;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
 import org.bonitasoft.engine.transaction.TransactionService;
@@ -75,6 +76,9 @@ public class ConcurrencyIT {
 
     private UserTransaction ut;
 
+    private ClassLoaderService classLoaderService = mock(ClassLoaderService.class);
+    private TechnicalLoggerService loggerService = mock(TechnicalLoggerService.class);
+
     @BeforeClass
     public static void initializeBitronix() {
         System.setProperty(Context.INITIAL_CONTEXT_FACTORY, "bitronix.tm.jndi.BitronixInitialContextFactory");
@@ -96,7 +100,7 @@ public class ConcurrencyIT {
         final SchemaManager schemaManager = new SchemaManager(modelConfiguration, mock(TechnicalLoggerService.class));
         final BusinessDataModelRepositoryImpl businessDataModelRepositoryImpl = spy(new BusinessDataModelRepositoryImpl(mock(DependencyService.class),
                 schemaManager, 1L));
-        businessDataRepository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepositoryImpl, configuration));
+        businessDataRepository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepositoryImpl, loggerService, configuration, classLoaderService, 1L));
         doReturn(true).when(businessDataModelRepositoryImpl).isDBMDeployed();
 
         ut = TransactionManagerServices.getTransactionManager();

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImplITest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImplITest.java
@@ -31,12 +31,17 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Resource;
 import javax.naming.Context;
 import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
 
+import bitronix.tm.TransactionManagerServices;
+import com.company.pojo.Employee;
+import com.company.pojo.Person;
+import org.bonitasoft.engine.business.data.NonUniqueResultException;
+import org.bonitasoft.engine.business.data.SBusinessDataNotFoundException;
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 import org.bonitasoft.engine.dependency.DependencyService;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
 import org.bonitasoft.engine.transaction.TransactionService;
@@ -52,15 +57,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import bitronix.tm.TransactionManagerServices;
-
-import org.bonitasoft.engine.business.data.NonUniqueResultException;
-import org.bonitasoft.engine.business.data.SBusinessDataNotFoundException;
-import com.company.pojo.Employee;
-import com.company.pojo.Person;
-
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "/testContext.xml" })
+@ContextConfiguration(locations = {"/testContext.xml"})
 public class JPABusinessDataRepositoryImplITest {
 
     private JPABusinessDataRepositoryImpl businessDataRepository;
@@ -85,6 +83,10 @@ public class JPABusinessDataRepositoryImplITest {
 
     private UserTransaction ut;
 
+    private ClassLoaderService classLoaderService = mock(ClassLoaderService.class);
+
+    private TechnicalLoggerService loggerService = mock(TechnicalLoggerService.class);
+
     @BeforeClass
     public static void initializeBitronix() {
         System.setProperty(Context.INITIAL_CONTEXT_FACTORY, "bitronix.tm.jndi.BitronixInitialContextFactory");
@@ -107,7 +109,7 @@ public class JPABusinessDataRepositoryImplITest {
         final SchemaManager schemaManager = new SchemaManager(modelConfiguration, mock(TechnicalLoggerService.class));
         final BusinessDataModelRepositoryImpl businessDataModelRepositoryImpl = spy(new BusinessDataModelRepositoryImpl(mock(DependencyService.class),
                 schemaManager, 1L));
-        businessDataRepository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepositoryImpl, configuration));
+        businessDataRepository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepositoryImpl, loggerService,  configuration, classLoaderService, 1L));
         doReturn(true).when(businessDataModelRepositoryImpl).isDBMDeployed();
         ut = TransactionManagerServices.getTransactionManager();
         ut.begin();
@@ -206,22 +208,22 @@ public class JPABusinessDataRepositoryImplITest {
         Employee emp1 = addEmployeeToRepository(anEmployee().withLastName(lastName).build());
         Employee emp2 = addEmployeeToRepository(anEmployee().withLastName(lastName).build());
         Employee emp3 = addEmployeeToRepository(anEmployee().withLastName(lastName).build());
-        
+
         List<Employee> emps = businessDataRepository.findByIds(Employee.class, Arrays.asList(emp1.getPersistenceId(), emp2.getPersistenceId()));
-        
+
         assertThat(emps).contains(emp1, emp2);
         assertThat(emps).doesNotContain(emp3);
     }
-    
+
     @Test
     public void should_return_an_empty_list_when_getting_entities_with_empty_ids_list() throws Exception {
-       ArrayList<Long> emptyIdsList = new ArrayList<Long>();
-        
+        ArrayList<Long> emptyIdsList = new ArrayList<Long>();
+
         List<Employee> emps = businessDataRepository.findByIds(Employee.class, emptyIdsList);
-        
+
         assertThat(emps).isEmpty();
     }
-    
+
     @Test
     public void returnNullnWhenFindingAnUnknownEmployee() throws Exception {
         final Map<String, Serializable> parameters = Collections.singletonMap("lastName", (Serializable) "Unknown_lastName");

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImplTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImplTest.java
@@ -16,25 +16,29 @@ package org.bonitasoft.engine.business.data.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
-
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
+import org.bonitasoft.engine.bdm.Entity;
+import org.bonitasoft.engine.business.data.BusinessDataModelRepository;
+import org.bonitasoft.engine.business.data.SBusinessDataNotFoundException;
+import org.bonitasoft.engine.classloader.ClassLoaderService;
+import org.bonitasoft.engine.dependency.model.ScopeType;
+import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
 import org.bonitasoft.engine.transaction.TransactionService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import org.bonitasoft.engine.bdm.Entity;
-import org.bonitasoft.engine.business.data.BusinessDataModelRepository;
-import org.bonitasoft.engine.business.data.SBusinessDataNotFoundException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JPABusinessDataRepositoryImplTest {
@@ -53,12 +57,55 @@ public class JPABusinessDataRepositoryImplTest {
     private Map<String, Object> configuration;
 
     @Mock
+    private ClassLoaderService classLoaderService;
+
+    @Mock
     EntityManager manager;
+
+    @Mock
+    private TechnicalLoggerService loggerService;
 
     @Before
     public void setUp() {
-        repository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepository, configuration));
+        repository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepository, loggerService, configuration, classLoaderService, 1L));
         doReturn(manager).when(repository).getEntityManager();
+    }
+
+    @Test
+    public void should_start_add_listener_on_classloader() throws Exception {
+        //given
+        doReturn(true).when(businessDataModelRepository).isDBMDeployed();
+        doReturn(mock(EntityManagerFactory.class)).when(repository).createEntityManagerFactory();
+        //when
+        repository.start();
+        //then
+        verify(classLoaderService).addListener(ScopeType.TENANT.name(), 1L, repository);
+    }
+
+    @Test
+    public void should_stop_remove_listener_on_classloader() throws Exception {
+        //given
+        doReturn(true).when(businessDataModelRepository).isDBMDeployed();
+        doReturn(mock(EntityManagerFactory.class)).when(repository).createEntityManagerFactory();
+        //when
+        repository.stop();
+        //then
+        verify(classLoaderService).removeListener(ScopeType.TENANT.name(), 1L, repository);
+    }
+
+    @Test
+    public void should_onUpdate_recreate_the_entity_manager_factory() throws Exception {
+        //given
+        doReturn(true).when(businessDataModelRepository).isDBMDeployed();
+        EntityManagerFactory entityManagerFactory = mock(EntityManagerFactory.class);
+        doReturn(entityManagerFactory).when(repository).createEntityManagerFactory();
+        doReturn(entityManagerFactory).when(repository).getEntityManagerFactory();
+        repository.start();
+        //when
+        repository.onUpdate(null);
+        //then
+        verify(entityManagerFactory).close();
+        verify(repository, times(2)).createEntityManagerFactory();
     }
 
     @Test

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImplTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImplTest.java
@@ -14,6 +14,7 @@
 package org.bonitasoft.engine.business.data.impl;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssert.assertThatJson;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,9 +41,11 @@ public class JsonBusinessDataSerializerImplTest {
 
     List<Entity> personList;
 
+    private ClassLoaderService classLoaderService = mock(ClassLoaderService.class);
+
     @Before
     public void setUp() throws Exception {
-        jsonBusinessDataSerializer = new JsonBusinessDataSerializerImpl();
+        jsonBusinessDataSerializer = new JsonBusinessDataSerializerImpl(classLoaderService);
 
     }
 


### PR DESCRIPTION
BusinessDataService use listeners to listen updates on the classloaders
and refresh itself by clearing cache in JSon and recreating the entity
manager factory. this remove all reference on the destroyed bonita
classloader

depends on https://github.com/bonitasoft/bonita-engine/pull/220