### PR TITLE
remove dangerous method in IOUtils

### DIFF
--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/EqualsBuilderTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/EqualsBuilderTest.java
@@ -16,17 +16,20 @@ package org.bonitasoft.engine.bdm;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Date;
 
 import org.bonitasoft.engine.commons.io.IOUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JType;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Romain Bioteau
@@ -40,11 +43,14 @@ public class EqualsBuilderTest extends CompilableCode {
 
     private File destDir;
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         codeGenerator = new CodeGenerator();
         equalsBuilder = new EqualsBuilder();
-        destDir = IOUtil.createTempDirectoryInDefaultTempDirectory("generationDir");
+        destDir = temporaryFolder.newFolder();
     }
 
     @After

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/HashCodeBuilderTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/HashCodeBuilderTest.java
@@ -22,12 +22,14 @@ import java.util.Date;
 import org.bonitasoft.engine.commons.io.IOUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JType;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Romain Bioteau
@@ -40,11 +42,14 @@ public class HashCodeBuilderTest extends CompilableCode {
 
     private File destDir;
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         codeGenerator = new CodeGenerator();
         hashCodeBuilder = new HashCodeBuilder();
-        destDir = IOUtil.createTempDirectoryInDefaultTempDirectory("generationDir");
+        destDir = temporaryFolder.newFolder();
     }
 
     @After

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/server/ServerBDMJarBuilderTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/bdm/server/ServerBDMJarBuilderTest.java
@@ -20,16 +20,16 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 
-import org.bonitasoft.engine.commons.io.IOUtil;
+import org.bonitasoft.engine.bdm.model.BusinessObjectModel;
+import org.bonitasoft.engine.compiler.JDTCompiler;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import org.bonitasoft.engine.bdm.model.BusinessObjectModel;
-import org.bonitasoft.engine.compiler.JDTCompiler;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ServerBDMJarBuilderTest {
@@ -37,11 +37,14 @@ public class ServerBDMJarBuilderTest {
     @Mock
     private BusinessObjectModel bom;
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     private File directory;
 
     @Before
     public void setUp() throws Exception {
-        directory = IOUtil.createTempDirectoryInDefaultTempDirectory(ServerBDMJarBuilderTest.class.getName());
+        directory = temporaryFolder.newFolder();
     }
 
     @After

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/compiler/JDTCompilerTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/compiler/JDTCompilerTest.java
@@ -25,7 +25,9 @@ import java.net.URLClassLoader;
 import org.bonitasoft.engine.commons.io.IOUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Colin PUY
@@ -36,11 +38,13 @@ public class JDTCompilerTest {
     private JDTCompiler jdtCompiler;
 
     private File outputDirectory;
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Before
-    public void instanciateCompiler() {
+    public void instanciateCompiler() throws IOException {
         jdtCompiler = new JDTCompiler();
-        outputDirectory = IOUtil.createTempDirectoryInDefaultTempDirectory("testFolder");
+        outputDirectory = temporaryFolder.newFolder();
     }
 
     @After

--- a/services/bonita-commons/src/main/java/org/bonitasoft/engine/commons/io/IOUtil.java
+++ b/services/bonita-commons/src/main/java/org/bonitasoft/engine/commons/io/IOUtil.java
@@ -30,12 +30,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.math.BigInteger;
-import java.net.URI;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,8 +57,6 @@ import org.bonitasoft.engine.commons.ClassDataUtil;
 import org.bonitasoft.engine.commons.NullCheckingUtil;
 import org.bonitasoft.engine.commons.Pair;
 import org.w3c.dom.Document;
-import sun.misc.IOUtils;
-import sun.security.util.ManifestDigester;
 
 /**
  * @author Elias Ricken de Medeiros
@@ -604,40 +600,6 @@ public class IOUtil {
             return file.mkdirs();
         }
         return true;
-    }
-
-    public static File createTempDirectoryInDefaultTempDirectory(final String directoryName) {
-        final File tmpDir = new File(TMP_DIRECTORY, directoryName + "_" + System.currentTimeMillis());
-        createTempDirectory(tmpDir);
-        return tmpDir;
-    }
-
-    public static File createTempDirectory(final URI directoryPath) {
-        final File tmpDir = new File(directoryPath);
-        createTempDirectory(tmpDir);
-        return tmpDir;
-    }
-
-    private static void createTempDirectory(final File tmpDir) {
-        tmpDir.setReadable(true);
-        tmpDir.setWritable(true);
-
-        mkdirs(tmpDir);
-
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-
-            @Override
-            public void run() {
-                try {
-                    final boolean deleted = deleteDir(tmpDir);
-                    if (!deleted) {
-                        System.err.println("Unable to delete the directory: " + tmpDir);
-                    }
-                } catch (final IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        });
     }
 
     public static byte[] getZipEntryContent(final String entryName, final InputStream inputStream) throws IOException {


### PR DESCRIPTION
this methods purpose was to create temporary folders
it was dangerous because it was registering a new shutdown hook for each
folder created
a shutdown hook is expensive in terms of memory because it create a
thread each time
use junit rule instead