### PR TITLE
update jackson version to 2.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spring.version>3.1.2.RELEASE</spring.version>
-        <jackson.version>2.2.3</jackson.version>
+        <jackson.version>2.4.4</jackson.version>
 		<jaxb.version>2.2.7</jaxb.version>
 
 		<!-- Tests -->


### PR DESCRIPTION
the version 2.4.4 is the same as the version used by restlet in the web
this is needed in order to call the clearCache on TypeFactory

depends on https://github.com/bonitasoft/bonita-engine/pull/220 and https://github.com/bonitasoft/bonita-engine/pull/221