### PR TITLE
Fix quartz shutdown with shutdown hook plugin

### DIFF
--- a/bpm/bonita-home/src/main/resources/bonita-platform-community.xml
+++ b/bpm/bonita-home/src/main/resources/bonita-platform-community.xml
@@ -25,6 +25,8 @@
                 <prop key="org.quartz.jobStore.dontSetAutoCommitFalse">true</prop>
                 <prop key="org.quartz.scheduler.wrapJobExecutionInUserTransaction">true</prop>
                 <prop key="org.quartz.scheduler.userTransactionURL">${userTransaction}</prop>
+                <prop key="org.quartz.plugin.shutdownhook.class">org.quartz.plugins.management.ShutdownHookPlugin</prop>
+                <prop key="org.quartz.plugin.shutdownhook.cleanShutdown">true</prop>
             </props>
         </property>
     </bean>

--- a/bpm/bonita-home/src/main/resources/bonita-platform-community.xml
+++ b/bpm/bonita-home/src/main/resources/bonita-platform-community.xml
@@ -26,7 +26,7 @@
                 <prop key="org.quartz.scheduler.wrapJobExecutionInUserTransaction">true</prop>
                 <prop key="org.quartz.scheduler.userTransactionURL">${userTransaction}</prop>
                 <prop key="org.quartz.plugin.shutdownhook.class">org.quartz.plugins.management.ShutdownHookPlugin</prop>
-                <prop key="org.quartz.plugin.shutdownhook.cleanShutdown">true</prop>
+                <prop key="org.quartz.plugin.shutdownhook.cleanShutdown">false</prop>
             </props>
         </property>
     </bean>


### PR DESCRIPTION
Merging PR https://github.com/bonitasoft/bonita-distrib/pull/22 made quartz locked while shutting down when used with H2 database on CI.
Using this quartz plugin to shutdown quartz scheduler when JVM is terminating.