### PR TITLE
BS-14736, change index on arch flow node instance

### DIFF
--- a/bpm/bonita-sql/src/main/resources/sql/h2/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/h2/createTables.sql
@@ -233,7 +233,7 @@ CREATE TABLE arch_flownode_instance (
   interrupting BOOLEAN,
   PRIMARY KEY (tenantid, id)
 );
-CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(kind, logicalGroup2, executedBy);
+CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(logicalGroup2, tenantId, kind, executedBy);
 CREATE INDEX idx_afi_kind_lg3 ON arch_flownode_instance(tenantId, kind, logicalGroup3);
 CREATE INDEX idx_afi_sourceId_tenantid_kind ON arch_flownode_instance (sourceObjectId, tenantid, kind);
 CREATE INDEX idx1_arch_flownode_instance ON arch_flownode_instance (tenantId, rootContainerId, parentContainerId);

--- a/bpm/bonita-sql/src/main/resources/sql/mysql/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/mysql/createTables.sql
@@ -237,7 +237,7 @@ CREATE TABLE arch_flownode_instance (
   interrupting BOOLEAN,
   PRIMARY KEY (tenantid, id)
 ) ENGINE = INNODB;
-CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(kind, logicalGroup2, executedBy);
+CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(logicalGroup2, tenantId, kind, executedBy);
 CREATE INDEX idx_afi_kind_lg3 ON arch_flownode_instance(tenantId, kind, logicalGroup3);
 CREATE INDEX idx_afi_sourceId_tenantid_kind ON arch_flownode_instance (sourceObjectId, tenantid, kind);
 CREATE INDEX idx1_arch_flownode_instance ON arch_flownode_instance (tenantId, rootContainerId, parentContainerId);

--- a/bpm/bonita-sql/src/main/resources/sql/oracle/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/oracle/createTables.sql
@@ -231,7 +231,7 @@ CREATE TABLE arch_flownode_instance (
   interrupting NUMBER(1),
   PRIMARY KEY (tenantid, id)
 );
-CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(kind, logicalGroup2, executedBy);
+CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(logicalGroup2, tenantId, kind, executedBy);
 CREATE INDEX idx_afi_kind_lg3 ON arch_flownode_instance(tenantId, kind, logicalGroup3);
 CREATE INDEX idx_afi_sourceId_tenantid_kind ON arch_flownode_instance (sourceObjectId, tenantid, kind);
 CREATE INDEX idx1_arch_flownode_instance ON arch_flownode_instance (tenantId, rootContainerId, parentContainerId);

--- a/bpm/bonita-sql/src/main/resources/sql/postgres/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/postgres/createTables.sql
@@ -233,7 +233,7 @@ CREATE TABLE arch_flownode_instance (
   interrupting BOOLEAN,
   PRIMARY KEY (tenantid, id)
 );
-CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(kind, logicalGroup2, executedBy);
+CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(logicalGroup2, tenantId, kind, executedBy);
 CREATE INDEX idx_afi_kind_lg3 ON arch_flownode_instance(tenantId, kind, logicalGroup3);
 CREATE INDEX idx_afi_sourceId_tenantid_kind ON arch_flownode_instance (sourceObjectId, tenantid, kind);
 CREATE INDEX idx1_arch_flownode_instance ON arch_flownode_instance (tenantId, rootContainerId, parentContainerId);

--- a/bpm/bonita-sql/src/main/resources/sql/sqlserver/createTables.sql
+++ b/bpm/bonita-sql/src/main/resources/sql/sqlserver/createTables.sql
@@ -260,7 +260,7 @@ CREATE TABLE arch_flownode_instance (
   PRIMARY KEY (tenantid, id)
 )
 GO
-CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(kind, logicalGroup2, executedBy)
+CREATE INDEX idx_afi_kind_lg2_executedBy ON arch_flownode_instance(logicalGroup2, tenantId, kind, executedBy);
 GO
 CREATE INDEX idx_afi_kind_lg3 ON arch_flownode_instance(tenantId, kind, logicalGroup3)
 GO


### PR DESCRIPTION
this fix the mysql slowness on search archive case involving user, on
big volume it goes from 45 minutes to 15 seconds for the count and 30ms
for the query

mainly it comes from the index order

in additions we should implement a count that only says that there is
more than e.g. 1000 element, with this the diplay will go on mysql from
15 seconds to arround 100ms

this issue was only on mysal but we keep the same index for other db
also. tested it on postgres, it is ok