### PR TITLE
BS-14661, make NONE formmapping create pagemapping

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/form/FormMappingIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/form/FormMappingIT.java
@@ -192,6 +192,27 @@ public class FormMappingIT extends TestWithUser {
     }
 
     @Test
+    public void resolvePageOrURL_should_return_null_mapping_for_NONE() throws Exception {
+        ProcessDefinitionBuilder p1Builder = new ProcessDefinitionBuilder().createNewInstance("CustomerSupport", "1.0");
+        p1Builder.addActor("actor").addUserTask("step", "actor");
+        BusinessArchiveBuilder bar = new BusinessArchiveBuilder()
+                .createNewBusinessArchive().setProcessDefinition(p1Builder.done())
+                .setFormMappings(FormMappingModelBuilder.buildFormMappingModel().addTaskForm(null, FormMappingTarget.NONE, "step").build());
+
+        ProcessDefinition processDefinition = deployProcess(bar.done());
+
+
+        // try to resolve url:
+        PageURL pageURL = getPageAPI().resolvePageOrURL("taskInstance/CustomerSupport/1.0/step", context, true);
+
+        assertThat(pageURL.getPageId()).isNull();
+        assertThat(pageURL.getUrl()).isNull();
+
+
+        deleteProcess(processDefinition);
+    }
+
+    @Test
     public void deployProcessWithInternalPagesIncludedShouldBeResolved() throws Exception {
         Page custompage_globalpage = getPageAPI().createPage("globalPage.zip", createTestPageContent("custompage_globalpage", "Global page", "a global page"));
         ProcessDefinitionBuilder processBuilder = new ProcessDefinitionBuilder().createNewInstance("CustomerSupport", "1.12");
@@ -237,7 +258,7 @@ public class FormMappingIT extends TestWithUser {
         final SubProcessDefinitionBuilder eventSubProc = p1Builder.addSubProcess("eventSubProc", true).getSubProcessBuilder();
         eventSubProc.addUserTask("subTask", "actor");
         eventSubProc.addStartEvent("start").addSignalEventTrigger("theSignal");
-        eventSubProc.addTransition("start","subTask");
+        eventSubProc.addTransition("start", "subTask");
 
         BusinessArchiveBuilder bar1 = new BusinessArchiveBuilder()
                 .createNewBusinessArchive()
@@ -247,7 +268,6 @@ public class FormMappingIT extends TestWithUser {
                                 .addTaskForm("task1Form", FormMappingTarget.INTERNAL, "step1")
                                 .addTaskForm("urlForThesubTask", FormMappingTarget.URL, "subTask")
                                 .addProcessOverviewForm("process1OverviewForm", FormMappingTarget.INTERNAL).build());
-
 
 
         ProcessDefinition p1 = getProcessAPI().deploy(bar1.done());

--- a/bpm/bonita-core/bonita-form-mapping/bonita-form-mapping-impl/src/main/java/org/bonitasoft/engine/core/form/impl/FormMappingServiceImpl.java
+++ b/bpm/bonita-core/bonita-form-mapping/bonita-form-mapping-impl/src/main/java/org/bonitasoft/engine/core/form/impl/FormMappingServiceImpl.java
@@ -114,7 +114,7 @@ public class FormMappingServiceImpl implements FormMappingService {
     public SFormMapping create(long processDefinitionId, String task, Integer type, String target, String form)
             throws SBonitaReadException, SObjectCreationException {
         if (target == null) {
-            throw new IllegalArgumentException("Illegal form target " + target);
+            throw new IllegalArgumentException("Form target is null");
         }
         SPageMapping sPageMapping;
         String key = formMappingKeyGenerator.generateKey(processDefinitionId, task, type);
@@ -133,7 +133,7 @@ public class FormMappingServiceImpl implements FormMappingService {
                 sPageMapping = null;
                 break;
             case SFormMapping.TARGET_NONE:
-                sPageMapping = null;
+                sPageMapping = pageMappingService.create(key, null, authorizationRules);
                 break;
             default:
                 throw new IllegalArgumentException("Illegal form target " + target);

--- a/bpm/bonita-core/bonita-form-mapping/bonita-form-mapping-impl/src/test/java/org/bonitasoft/engine/core/form/impl/FormMappingServiceImplTest.java
+++ b/bpm/bonita-core/bonita-form-mapping/bonita-form-mapping-impl/src/test/java/org/bonitasoft/engine/core/form/impl/FormMappingServiceImplTest.java
@@ -100,6 +100,14 @@ public class FormMappingServiceImplTest {
 
         verifyZeroInteractions(pageMappingService);
     }
+    @Test
+    public void createFormMapping_with_none_should_create_empty_form_mapping() throws Exception {
+        doReturn("mockedKey").when(formMappingKeyGenerator).generateKey(PROCESS_DEFINITION_ID, "someHumanTask", 84);
+
+        formMappingService.create(PROCESS_DEFINITION_ID, "someHumanTask", 84, SFormMapping.TARGET_NONE, null);
+
+        verify(pageMappingService).create(eq("mockedKey"), (Long) eq(null), anyList());
+    }
 
     @Test
     public void createWithInternalPageShouldCallPageMapping_create() throws Exception {

--- a/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/resolver/DocumentInitialValueArtifactManagerTest.java
+++ b/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/resolver/DocumentInitialValueArtifactManagerTest.java
@@ -41,7 +41,7 @@ import org.mockito.runners.MockitoJUnitRunner;
  * @author Baptiste Mesta
  */
 @RunWith(MockitoJUnitRunner.class)
-public class DocumentInitialValueDependencyManagerTest {
+public class DocumentInitialValueArtifactManagerTest {
 
     public static final long PROCESS_ID = 456L;
     @Mock

--- a/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/resolver/FormMappingAndPageArtifactManagerTest.java
+++ b/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/api/impl/resolver/FormMappingAndPageArtifactManagerTest.java
@@ -58,7 +58,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 @RunWith(MockitoJUnitRunner.class)
-public class FormMappingAndPageDependencyManagerTest {
+public class FormMappingAndPageArtifactManagerTest {
 
     public static final String PAGE = "myPage";
     public static final byte[] CONTENT1 = "content1".getBytes();


### PR DESCRIPTION
this is to avoid not found when a form mapping is to none and you call
the resolvePageOrUrl method

the method now returns a pagemapping object with no pageid nor url

this still can be updated to other values