### PR TITLE
Use global listeners to clear reference to classes

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
@@ -1510,11 +1510,13 @@ public class BDRepositoryIT extends CommonAPIIT {
         parameters.put("queryParameters", (Serializable) queryParameters);
 
         // when
-        final BusinessDataQueryResult businessDataQueryResult = (BusinessDataQueryResult) getCommandAPI().execute("getBusinessDataByQueryCommand", parameters);
+        ((BusinessDataQueryResult) getCommandAPI().execute("getBusinessDataByQueryCommand", parameters)).getJsonResults();
+        getCommandAPI().addDependency("temporaryDeps", new byte[] {0, 1});
+        Serializable jsonResult = ((BusinessDataQueryResult) getCommandAPI().execute("getBusinessDataByQueryCommand", parameters)).getJsonResults();
+
 
         // then
-        assertThatJson(businessDataQueryResult.getJsonResults()).as("should get employee")
-                .hasSameStructureAs(getJsonContent("findByFirstNameAndLastNameNewOrder.json"));
+        assertThatJson(jsonResult).as("should get employee").hasSameStructureAs(getJsonContent("findByFirstNameAndLastNameNewOrder.json"));
 
     }
 

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/XpathUpdateQueryOperationExecutorStrategy.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/XpathUpdateQueryOperationExecutorStrategy.java
@@ -77,8 +77,6 @@ public class XpathUpdateQueryOperationExecutorStrategy implements OperationExecu
             final String dataInstanceName = operation.getLeftOperand().getName();
             // should be a String because the data is an xml expression
             final String dataValue = (String) expressionContext.getInputValues().get(dataInstanceName);
-            final SExpressionContext sExpressionContext = new SExpressionContext();
-            sExpressionContext.setInputValues(expressionContext.getInputValues());
             final Object variableValue = value;
 
             final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();

--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/command/ExecuteBDMQueryCommand.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/command/ExecuteBDMQueryCommand.java
@@ -21,9 +21,11 @@ import org.bonitasoft.engine.business.data.BusinessDataRepository;
 import org.bonitasoft.engine.business.data.NonUniqueResultException;
 import org.bonitasoft.engine.command.system.CommandWithParameters;
 import org.bonitasoft.engine.service.TenantServiceAccessor;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 
 /**
  * @author Romain Bioteau
@@ -76,6 +78,7 @@ public class ExecuteBDMQueryCommand extends CommandWithParameters {
     private byte[] serializeResult(final Serializable result) throws SCommandExecutionException {
         final ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+        ((DefaultSerializerProvider) mapper.getSerializerProvider()).flushCachedSerializers();
         try {
             return mapper.writeValueAsBytes(result);
         } catch (final JsonProcessingException jpe) {

--- a/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
+++ b/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
@@ -1528,6 +1528,9 @@
                 <entry key="javax.persistence.validation.mode" value="${bonita.tenant.bdm.repository.javax.persistence.validation.mode}" />
             </map>
         </constructor-arg>
+        <constructor-arg name="loggerService" ref="tenantTechnicalLoggerService" />
+        <constructor-arg name="classLoaderService" ref="classLoaderService" />
+        <constructor-arg name="tenantId" value="${tenantId}" />
     </bean>
 
     <bean id="businessDataModelRepository"
@@ -1555,7 +1558,9 @@
     </bean>
 
     <bean id="jsonBusinessDataSerializer"
-          class="org.bonitasoft.engine.business.data.impl.JsonBusinessDataSerializerImpl" />
+          class="org.bonitasoft.engine.business.data.impl.JsonBusinessDataSerializerImpl" >
+        <constructor-arg name="classLoaderService" ref="classLoaderService" />
+    </bean>
 
     <bean id="typeConverterUtil" class="org.bonitasoft.engine.commons.TypeConverterUtil">
         <constructor-arg name="datePatterns" type="java.lang.String[]">

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spring.version>3.1.2.RELEASE</spring.version>
-        <jackson.version>2.2.3</jackson.version>
+        <jackson.version>2.4.4</jackson.version>
 		<jaxb.version>2.2.7</jaxb.version>
 
 		<!-- Tests -->

--- a/services/bonita-business-data/bonita-business-data-api/src/main/java/org/bonitasoft/engine/business/data/proxy/ServerProxyfier.java
+++ b/services/bonita-business-data/bonita-business-data-api/src/main/java/org/bonitasoft/engine/business/data/proxy/ServerProxyfier.java
@@ -55,7 +55,9 @@ public class ServerProxyfier {
         if (entity == null) {
             return null;
         }
+
         final ProxyFactory factory = new ProxyFactory();
+        factory.setUseCache(false);
         Class<?> classForProxy = entity.getClass();
 
         //It's not possible to create a Proxy on a Proxy

--- a/services/bonita-business-data/bonita-business-data-client-resources/src/main/java/org/bonitasoft/engine/bdm/dao/client/resources/proxy/Proxyfier.java
+++ b/services/bonita-business-data/bonita-business-data-client-resources/src/main/java/org/bonitasoft/engine/bdm/dao/client/resources/proxy/Proxyfier.java
@@ -46,6 +46,7 @@ public class Proxyfier {
             return null;
         }
         final ProxyFactory factory = new ProxyFactory();
+        factory.setUseCache(false);
         factory.setSuperclass(entity.getClass());
         factory.setFilter(new AllMethodFilter());
         try {

--- a/services/bonita-business-data/bonita-business-data-impl/pom.xml
+++ b/services/bonita-business-data/bonita-business-data-impl/pom.xml
@@ -111,6 +111,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.bonitasoft.engine.classloader</groupId>
+            <artifactId>bonita-classloader-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/BusinessDataServiceImpl.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/BusinessDataServiceImpl.java
@@ -263,10 +263,14 @@ public class BusinessDataServiceImpl implements BusinessDataService {
 
     private Serializable buildJsonRepresentation(final Entity entity, final String businessDataURIPattern) throws SBusinessDataRepositoryException {
         try {
-            return jsonBusinessDataSerializer.serializeEntity(entity, businessDataURIPattern);
+            return serializeJson(entity, businessDataURIPattern);
         } catch (final IOException e) {
             throw new SBusinessDataRepositoryException(e);
         }
+    }
+
+    private String serializeJson(Entity entity, String businessDataURIPattern) throws IOException {
+        return jsonBusinessDataSerializer.serializeEntity(entity, businessDataURIPattern);
     }
 
     private Serializable buildJsonRepresentation(final List<Entity> entities, final String businessDataURIPattern) throws SBusinessDataRepositoryException {

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImpl.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImpl.java
@@ -20,21 +20,28 @@ import java.util.List;
 import org.bonitasoft.engine.bdm.Entity;
 import org.bonitasoft.engine.business.data.JsonBusinessDataSerializer;
 import org.bonitasoft.engine.business.data.impl.utils.JsonNumberSerializerHelper;
+import org.bonitasoft.engine.classloader.ClassLoaderListener;
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
-public class JsonBusinessDataSerializerImpl implements JsonBusinessDataSerializer {
+public class JsonBusinessDataSerializerImpl implements JsonBusinessDataSerializer, ClassLoaderListener {
 
-    private final ObjectMapper mapper;
+    private ObjectMapper mapper;
 
-    private final EntitySerializer serializer;
+    private EntitySerializer serializer;
 
-    public JsonBusinessDataSerializerImpl() {
-        mapper = new ObjectMapper();
+    public JsonBusinessDataSerializerImpl(ClassLoaderService classLoaderService) {
+        init();
+        classLoaderService.addListener(this);
+    }
+
+    private void init() {
         serializer = new EntitySerializer(new JsonNumberSerializerHelper());
+        mapper = new ObjectMapper();
         final SimpleModule hbm = new SimpleModule();
         hbm.addSerializer(serializer);
         mapper.registerModule(hbm);
@@ -58,4 +65,13 @@ public class JsonBusinessDataSerializerImpl implements JsonBusinessDataSerialize
         return writer.toString();
     }
 
+    @Override
+    public void onUpdate(ClassLoader newClassLoader) {
+        init();
+    }
+
+    @Override
+    public void onDestroy(ClassLoader oldClassLoader) {
+        init();
+    }
 }

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/ConcurrencyIT.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/ConcurrencyIT.java
@@ -32,6 +32,7 @@ import javax.naming.Context;
 import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
 
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 import org.bonitasoft.engine.dependency.DependencyService;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
 import org.bonitasoft.engine.transaction.TransactionService;
@@ -75,6 +76,9 @@ public class ConcurrencyIT {
 
     private UserTransaction ut;
 
+    private ClassLoaderService classLoaderService = mock(ClassLoaderService.class);
+    private TechnicalLoggerService loggerService = mock(TechnicalLoggerService.class);
+
     @BeforeClass
     public static void initializeBitronix() {
         System.setProperty(Context.INITIAL_CONTEXT_FACTORY, "bitronix.tm.jndi.BitronixInitialContextFactory");
@@ -96,7 +100,7 @@ public class ConcurrencyIT {
         final SchemaManager schemaManager = new SchemaManager(modelConfiguration, mock(TechnicalLoggerService.class));
         final BusinessDataModelRepositoryImpl businessDataModelRepositoryImpl = spy(new BusinessDataModelRepositoryImpl(mock(DependencyService.class),
                 schemaManager, 1L));
-        businessDataRepository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepositoryImpl, configuration));
+        businessDataRepository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepositoryImpl, loggerService, configuration, classLoaderService, 1L));
         doReturn(true).when(businessDataModelRepositoryImpl).isDBMDeployed();
 
         ut = TransactionManagerServices.getTransactionManager();

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImplTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImplTest.java
@@ -14,6 +14,7 @@
 package org.bonitasoft.engine.business.data.impl;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssert.assertThatJson;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,9 +41,11 @@ public class JsonBusinessDataSerializerImplTest {
 
     List<Entity> personList;
 
+    private ClassLoaderService classLoaderService = mock(ClassLoaderService.class);
+
     @Before
     public void setUp() throws Exception {
-        jsonBusinessDataSerializer = new JsonBusinessDataSerializerImpl();
+        jsonBusinessDataSerializer = new JsonBusinessDataSerializerImpl(classLoaderService);
 
     }
 


### PR DESCRIPTION
BusinessDataService use listeners to listen updates on the classloaders
and refresh itself by clearing cache in JSon and recreating the entity
manager factory. this remove all reference on the destroyed bonita
classloader