### PR TITLE
Make persistence except from the BDR be retryable

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
@@ -1510,11 +1510,13 @@ public class BDRepositoryIT extends CommonAPIIT {
         parameters.put("queryParameters", (Serializable) queryParameters);
 
         // when
-        final BusinessDataQueryResult businessDataQueryResult = (BusinessDataQueryResult) getCommandAPI().execute("getBusinessDataByQueryCommand", parameters);
+        ((BusinessDataQueryResult) getCommandAPI().execute("getBusinessDataByQueryCommand", parameters)).getJsonResults();
+        getCommandAPI().addDependency("temporaryDeps", new byte[] {0, 1});
+        Serializable jsonResult = ((BusinessDataQueryResult) getCommandAPI().execute("getBusinessDataByQueryCommand", parameters)).getJsonResults();
+
 
         // then
-        assertThatJson(businessDataQueryResult.getJsonResults()).as("should get employee")
-                .hasSameStructureAs(getJsonContent("findByFirstNameAndLastNameNewOrder.json"));
+        assertThatJson(jsonResult).as("should get employee").hasSameStructureAs(getJsonContent("findByFirstNameAndLastNameNewOrder.json"));
 
     }
 

--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/business/data/BDRepositoryIT.java
@@ -388,7 +388,6 @@ public class BDRepositoryIT extends CommonAPIIT {
         bo.addField(field);
         final BusinessObjectModel model = new BusinessObjectModel();
         model.addBusinessObject(bo);
-        final BusinessObjectModelConverter converter = new BusinessObjectModelConverter();
         return model;
     }
 

--- a/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/XpathUpdateQueryOperationExecutorStrategy.java
+++ b/bpm/bonita-core/bonita-operation/bonita-operation-api-impl/src/main/java/org/bonitasoft/engine/core/operation/impl/XpathUpdateQueryOperationExecutorStrategy.java
@@ -77,8 +77,6 @@ public class XpathUpdateQueryOperationExecutorStrategy implements OperationExecu
             final String dataInstanceName = operation.getLeftOperand().getName();
             // should be a String because the data is an xml expression
             final String dataValue = (String) expressionContext.getInputValues().get(dataInstanceName);
-            final SExpressionContext sExpressionContext = new SExpressionContext();
-            sExpressionContext.setInputValues(expressionContext.getInputValues());
             final Object variableValue = value;
 
             final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();

--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/command/ExecuteBDMQueryCommand.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/command/ExecuteBDMQueryCommand.java
@@ -21,9 +21,11 @@ import org.bonitasoft.engine.business.data.BusinessDataRepository;
 import org.bonitasoft.engine.business.data.NonUniqueResultException;
 import org.bonitasoft.engine.command.system.CommandWithParameters;
 import org.bonitasoft.engine.service.TenantServiceAccessor;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 
 /**
  * @author Romain Bioteau
@@ -76,6 +78,7 @@ public class ExecuteBDMQueryCommand extends CommandWithParameters {
     private byte[] serializeResult(final Serializable result) throws SCommandExecutionException {
         final ObjectMapper mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+        ((DefaultSerializerProvider) mapper.getSerializerProvider()).flushCachedSerializers();
         try {
             return mapper.writeValueAsBytes(result);
         } catch (final JsonProcessingException jpe) {

--- a/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
+++ b/bpm/bonita-home/src/main/resources/bonita-tenant-community.xml
@@ -1528,6 +1528,9 @@
                 <entry key="javax.persistence.validation.mode" value="${bonita.tenant.bdm.repository.javax.persistence.validation.mode}" />
             </map>
         </constructor-arg>
+        <constructor-arg name="loggerService" ref="tenantTechnicalLoggerService" />
+        <constructor-arg name="classLoaderService" ref="classLoaderService" />
+        <constructor-arg name="tenantId" value="${tenantId}" />
     </bean>
 
     <bean id="businessDataModelRepository"
@@ -1555,7 +1558,9 @@
     </bean>
 
     <bean id="jsonBusinessDataSerializer"
-          class="org.bonitasoft.engine.business.data.impl.JsonBusinessDataSerializerImpl" />
+          class="org.bonitasoft.engine.business.data.impl.JsonBusinessDataSerializerImpl" >
+        <constructor-arg name="classLoaderService" ref="classLoaderService" />
+    </bean>
 
     <bean id="typeConverterUtil" class="org.bonitasoft.engine.commons.TypeConverterUtil">
         <constructor-arg name="datePatterns" type="java.lang.String[]">

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spring.version>3.1.2.RELEASE</spring.version>
-        <jackson.version>2.2.3</jackson.version>
+        <jackson.version>2.4.4</jackson.version>
 		<jaxb.version>2.2.7</jaxb.version>
 
 		<!-- Tests -->

--- a/services/bonita-business-data/bonita-business-data-api/src/main/java/org/bonitasoft/engine/business/data/proxy/ServerProxyfier.java
+++ b/services/bonita-business-data/bonita-business-data-api/src/main/java/org/bonitasoft/engine/business/data/proxy/ServerProxyfier.java
@@ -55,7 +55,9 @@ public class ServerProxyfier {
         if (entity == null) {
             return null;
         }
+
         final ProxyFactory factory = new ProxyFactory();
+        factory.setUseCache(false);
         Class<?> classForProxy = entity.getClass();
 
         //It's not possible to create a Proxy on a Proxy

--- a/services/bonita-business-data/bonita-business-data-client-resources/src/main/java/org/bonitasoft/engine/bdm/dao/client/resources/proxy/Proxyfier.java
+++ b/services/bonita-business-data/bonita-business-data-client-resources/src/main/java/org/bonitasoft/engine/bdm/dao/client/resources/proxy/Proxyfier.java
@@ -46,6 +46,7 @@ public class Proxyfier {
             return null;
         }
         final ProxyFactory factory = new ProxyFactory();
+        factory.setUseCache(false);
         factory.setSuperclass(entity.getClass());
         factory.setFilter(new AllMethodFilter());
         try {

--- a/services/bonita-business-data/bonita-business-data-impl/pom.xml
+++ b/services/bonita-business-data/bonita-business-data-impl/pom.xml
@@ -111,6 +111,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.bonitasoft.engine.classloader</groupId>
+            <artifactId>bonita-classloader-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/BusinessDataServiceImpl.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/BusinessDataServiceImpl.java
@@ -263,10 +263,14 @@ public class BusinessDataServiceImpl implements BusinessDataService {
 
     private Serializable buildJsonRepresentation(final Entity entity, final String businessDataURIPattern) throws SBusinessDataRepositoryException {
         try {
-            return jsonBusinessDataSerializer.serializeEntity(entity, businessDataURIPattern);
+            return serializeJson(entity, businessDataURIPattern);
         } catch (final IOException e) {
             throw new SBusinessDataRepositoryException(e);
         }
+    }
+
+    private String serializeJson(Entity entity, String businessDataURIPattern) throws IOException {
+        return jsonBusinessDataSerializer.serializeEntity(entity, businessDataURIPattern);
     }
 
     private Serializable buildJsonRepresentation(final List<Entity> entities, final String businessDataURIPattern) throws SBusinessDataRepositoryException {

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImpl.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImpl.java
@@ -27,6 +27,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.NoResultException;
 import javax.persistence.Persistence;
+import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -44,6 +45,7 @@ import org.bonitasoft.engine.classloader.ClassLoaderService;
 import org.bonitasoft.engine.dependency.model.ScopeType;
 import org.bonitasoft.engine.log.technical.TechnicalLogSeverity;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
+import org.bonitasoft.engine.persistence.SRetryableException;
 import org.bonitasoft.engine.transaction.STransactionNotFoundException;
 import org.bonitasoft.engine.transaction.TransactionService;
 import org.hibernate.Hibernate;
@@ -183,7 +185,13 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository, Cl
             throw new SBusinessDataNotFoundException("Impossible to get data of type " + entityClass.getName() + " with a null identifier");
         }
         final EntityManager em = getEntityManager();
-        final T entity = em.find(entityClass, primaryKey);
+        final T entity;
+        try {
+            entity = em.find(entityClass, primaryKey);
+        } catch (PersistenceException e) {
+            //wrap in retryable exception because the issue might come from BDR reloading
+            throw new SRetryableException(e);
+        }
         if (entity == null) {
             throw new SBusinessDataNotFoundException("Impossible to get data of type " + entityClass.getName() + " with id: " + primaryKey);
         }
@@ -196,11 +204,16 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository, Cl
             return new ArrayList<T>();
         }
         final EntityManager em = getEntityManager();
-        final CriteriaBuilder cb = em.getCriteriaBuilder();
-        final CriteriaQuery<T> criteriaQuery = cb.createQuery(entityClass);
-        final Root<T> row = criteriaQuery.from(entityClass);
-        criteriaQuery.select(row).where(row.get(Field.PERSISTENCE_ID).in(primaryKeys));
-        return em.createQuery(criteriaQuery).getResultList();
+        try {
+            final CriteriaBuilder cb = em.getCriteriaBuilder();
+            final CriteriaQuery<T> criteriaQuery = cb.createQuery(entityClass);
+            final Root<T> row = criteriaQuery.from(entityClass);
+            criteriaQuery.select(row).where(row.get(Field.PERSISTENCE_ID).in(primaryKeys));
+            return em.createQuery(criteriaQuery).getResultList();
+        } catch (PersistenceException e) {
+            //wrap in retryable exception because the issue might come from BDR reloading
+            throw new SRetryableException(e);
+        }
     }
 
     @Override
@@ -242,30 +255,48 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository, Cl
     public <T extends Serializable> T find(final Class<T> resultClass, final String jpqlQuery, final Map<String, Serializable> parameters)
             throws NonUniqueResultException {
         final TypedQuery<T> typedQuery = createTypedQuery(jpqlQuery, resultClass);
-        return find(resultClass, typedQuery, parameters);
+        try {
+            return find(resultClass, typedQuery, parameters);
+        } catch (PersistenceException e) {
+            throw new SRetryableException(e);
+        }
     }
 
     @Override
     public <T extends Serializable> List<T> findList(final Class<T> resultClass, final String jpqlQuery, final Map<String, Serializable> parameters,
             final int startIndex, final int maxResults) {
         final TypedQuery<T> typedQuery = createTypedQuery(jpqlQuery, resultClass);
-        return findList(typedQuery, parameters, startIndex, maxResults);
+        try {
+            return findList(typedQuery, parameters, startIndex, maxResults);
+        } catch (PersistenceException e) {
+            throw new SRetryableException(e);
+        }
     }
 
     @Override
     public <T extends Serializable> T findByNamedQuery(final String queryName, final Class<T> resultClass, final Map<String, Serializable> parameters)
             throws NonUniqueResultException {
         final EntityManager em = getEntityManager();
-        final TypedQuery<T> query = em.createNamedQuery(queryName, resultClass);
-        return find(resultClass, query, parameters);
+        try {
+            final TypedQuery<T> query = em.createNamedQuery(queryName, resultClass);
+            return find(resultClass, query, parameters);
+        } catch (PersistenceException e) {
+            //wrap in retryable exception because the issue might come from BDR reloading
+            throw new SRetryableException(e);
+        }
     }
 
     @Override
     public <T extends Serializable> List<T> findListByNamedQuery(final String queryName, final Class<T> resultClass,
             final Map<String, Serializable> parameters, final int startIndex, final int maxResults) {
         final EntityManager em = getEntityManager();
-        final TypedQuery<T> query = em.createNamedQuery(queryName, resultClass);
-        return findList(query, parameters, startIndex, maxResults);
+        try {
+            final TypedQuery<T> query = em.createNamedQuery(queryName, resultClass);
+            return findList(query, parameters, startIndex, maxResults);
+        } catch (PersistenceException e) {
+            //wrap in retryable exception because the issue might come from BDR reloading
+            throw new SRetryableException(e);
+        }
     }
 
     private <T> TypedQuery<T> createTypedQuery(final String jpqlQuery, final Class<T> resultClass) {
@@ -291,21 +322,34 @@ public class JPABusinessDataRepositoryImpl implements BusinessDataRepository, Cl
     public void remove(final Entity entity) {
         if (entity != null && entity.getPersistenceId() != null) {
             final EntityManager em = getEntityManager();
-            em.remove(entity);
+            try {
+                em.remove(entity);
+            } catch (PersistenceException e) {
+                throw new SRetryableException(e);
+            }
         }
     }
 
     @Override
     public void persist(final Entity entity) {
         if (entity != null) {
-            getEntityManager().persist(entity);
+            EntityManager entityManager = getEntityManager();
+            try {
+                entityManager.persist(entity);
+            } catch (PersistenceException e) {
+                throw new SRetryableException(e);
+            }
         }
     }
 
     @Override
     public Entity merge(final Entity entity) {
         if (entity != null) {
-            return getEntityManager().merge(entity);
+            try {
+                return getEntityManager().merge(entity);
+            } catch (PersistenceException e) {
+                throw new SRetryableException(e);
+            }
         }
         return null;
     }

--- a/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImpl.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/main/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImpl.java
@@ -20,21 +20,28 @@ import java.util.List;
 import org.bonitasoft.engine.bdm.Entity;
 import org.bonitasoft.engine.business.data.JsonBusinessDataSerializer;
 import org.bonitasoft.engine.business.data.impl.utils.JsonNumberSerializerHelper;
+import org.bonitasoft.engine.classloader.ClassLoaderListener;
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
-public class JsonBusinessDataSerializerImpl implements JsonBusinessDataSerializer {
+public class JsonBusinessDataSerializerImpl implements JsonBusinessDataSerializer, ClassLoaderListener {
 
-    private final ObjectMapper mapper;
+    private ObjectMapper mapper;
 
-    private final EntitySerializer serializer;
+    private EntitySerializer serializer;
 
-    public JsonBusinessDataSerializerImpl() {
-        mapper = new ObjectMapper();
+    public JsonBusinessDataSerializerImpl(ClassLoaderService classLoaderService) {
+        init();
+        classLoaderService.addListener(this);
+    }
+
+    private void init() {
         serializer = new EntitySerializer(new JsonNumberSerializerHelper());
+        mapper = new ObjectMapper();
         final SimpleModule hbm = new SimpleModule();
         hbm.addSerializer(serializer);
         mapper.registerModule(hbm);
@@ -58,4 +65,13 @@ public class JsonBusinessDataSerializerImpl implements JsonBusinessDataSerialize
         return writer.toString();
     }
 
+    @Override
+    public void onUpdate(ClassLoader newClassLoader) {
+        init();
+    }
+
+    @Override
+    public void onDestroy(ClassLoader oldClassLoader) {
+        init();
+    }
 }

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/ConcurrencyIT.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/ConcurrencyIT.java
@@ -32,6 +32,7 @@ import javax.naming.Context;
 import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
 
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 import org.bonitasoft.engine.dependency.DependencyService;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
 import org.bonitasoft.engine.transaction.TransactionService;
@@ -75,6 +76,9 @@ public class ConcurrencyIT {
 
     private UserTransaction ut;
 
+    private ClassLoaderService classLoaderService = mock(ClassLoaderService.class);
+    private TechnicalLoggerService loggerService = mock(TechnicalLoggerService.class);
+
     @BeforeClass
     public static void initializeBitronix() {
         System.setProperty(Context.INITIAL_CONTEXT_FACTORY, "bitronix.tm.jndi.BitronixInitialContextFactory");
@@ -96,7 +100,7 @@ public class ConcurrencyIT {
         final SchemaManager schemaManager = new SchemaManager(modelConfiguration, mock(TechnicalLoggerService.class));
         final BusinessDataModelRepositoryImpl businessDataModelRepositoryImpl = spy(new BusinessDataModelRepositoryImpl(mock(DependencyService.class),
                 schemaManager, 1L));
-        businessDataRepository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepositoryImpl, configuration));
+        businessDataRepository = spy(new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepositoryImpl, loggerService, configuration, classLoaderService, 1L));
         doReturn(true).when(businessDataModelRepositoryImpl).isDBMDeployed();
 
         ut = TransactionManagerServices.getTransactionManager();

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImplTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JPABusinessDataRepositoryImplTest.java
@@ -15,7 +15,9 @@ package org.bonitasoft.engine.business.data.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -23,10 +25,20 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.Serializable;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Selection;
 
 import org.bonitasoft.engine.bdm.Entity;
 import org.bonitasoft.engine.business.data.BusinessDataModelRepository;
@@ -34,6 +46,7 @@ import org.bonitasoft.engine.business.data.SBusinessDataNotFoundException;
 import org.bonitasoft.engine.classloader.ClassLoaderService;
 import org.bonitasoft.engine.dependency.model.ScopeType;
 import org.bonitasoft.engine.log.technical.TechnicalLoggerService;
+import org.bonitasoft.engine.persistence.SRetryableException;
 import org.bonitasoft.engine.transaction.TransactionService;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,6 +84,16 @@ public class JPABusinessDataRepositoryImplTest {
         repository = spy(
                 new JPABusinessDataRepositoryImpl(transactionService, businessDataModelRepository, loggerService, configuration, classLoaderService, 1L));
         doReturn(manager).when(repository).getEntityManager();
+        doReturn(true).when(businessDataModelRepository).isDBMDeployed();
+        CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+        doReturn(criteriaBuilder).when(manager).getCriteriaBuilder();
+        CriteriaQuery criteriaQuery = mock(CriteriaQuery.class);
+        doReturn(criteriaQuery).when(criteriaBuilder).createQuery(any(Class.class));
+        doReturn(criteriaQuery).when(criteriaQuery).where(any(Expression.class));
+        doReturn(criteriaQuery).when(criteriaQuery).select(any(Selection.class));
+        Root root = mock(Root.class);
+        doReturn(root).when(criteriaQuery).from(any(Class.class));
+        doReturn(mock(Path.class)).when(root).get(anyString());
     }
 
     @Test
@@ -98,7 +121,6 @@ public class JPABusinessDataRepositoryImplTest {
     @Test
     public void should_onUpdate_recreate_the_entity_manager_factory() throws Exception {
         //given
-        doReturn(true).when(businessDataModelRepository).isDBMDeployed();
         EntityManagerFactory entityManagerFactory = mock(EntityManagerFactory.class);
         doReturn(entityManagerFactory).when(repository).createEntityManagerFactory();
         doReturn(entityManagerFactory).when(repository).getEntityManagerFactory();
@@ -131,6 +153,101 @@ public class JPABusinessDataRepositoryImplTest {
     @Test(expected = SBusinessDataNotFoundException.class)
     public void findById_should_throw_an_exception_with_a_null_identifier() throws Exception {
         repository.findById(Address.class, null);
+    }
+
+    @Test(expected = SRetryableException.class)
+    public void should_findById_throw_retryable_when_persistenceException() throws Exception {
+        //given
+        doThrow(PersistenceException.class).when(manager).find(Address.class,PRIMARY_KEY_1);
+        //when
+        repository.findById(Address.class,PRIMARY_KEY_1);
+        //then exception
+    }
+    @Test(expected = SRetryableException.class)
+    public void should_findByIds_throw_retryable_when_persistenceException() throws Exception {
+        //given
+        doThrow(PersistenceException.class).when(manager).createQuery(any(CriteriaQuery.class));
+        //when
+        repository.findByIds(Address.class, Collections.singletonList(PRIMARY_KEY_1));
+        //then exception
+    }
+
+    @Test(expected = SRetryableException.class)
+    public void should_findByIdentifiers_throw_retryable_when_persistenceException() throws Exception {
+        //given
+        doThrow(PersistenceException.class).when(manager).find(Address.class,PRIMARY_KEY_1);
+        //when
+        repository.findByIdentifiers(Address.class,Collections.singletonList(PRIMARY_KEY_1));
+        //then exception
+    }
+
+    @Test(expected = SRetryableException.class)
+    public void should_findByNamedQuery_throw_retryable_when_persistenceException() throws Exception {
+        //given
+        TypedQuery typedQuery = mock(TypedQuery.class);
+        doThrow(PersistenceException.class).when(typedQuery).getSingleResult();
+        doReturn(typedQuery).when(manager).createNamedQuery(anyString(),any(Class.class));
+        //when
+        repository.findByNamedQuery("queryName",Address.class,Collections.<String, Serializable>emptyMap());
+        //then exception
+    }
+    @Test(expected = SRetryableException.class)
+    public void should_findListByNamedQuery_throw_retryable_when_persistenceException() throws Exception {
+        //given
+        TypedQuery typedQuery = mock(TypedQuery.class);
+        doThrow(PersistenceException.class).when(typedQuery).getResultList();
+        doReturn(typedQuery).when(manager).createNamedQuery(anyString(),any(Class.class));
+        //when
+        repository.findListByNamedQuery("queryName",Address.class,Collections.<String, Serializable>emptyMap(),0,10);
+        //then exception
+    }
+
+    @Test(expected = SRetryableException.class)
+    public void should_find_throw_retryable_when_persistenceException() throws Exception {
+        //given
+        TypedQuery typedQuery = mock(TypedQuery.class);
+        doThrow(PersistenceException.class).when(typedQuery).getSingleResult();
+        doReturn(typedQuery).when(manager).createQuery(anyString(),any(Class.class));
+        //when
+        repository.find(Address.class,"the query as string",Collections.<String, Serializable>emptyMap());
+        //then exception
+    }
+    @Test(expected = SRetryableException.class)
+    public void should_findList_throw_retryable_when_persistenceException() throws Exception {
+        //given
+        TypedQuery typedQuery = mock(TypedQuery.class);
+        doThrow(PersistenceException.class).when(typedQuery).getResultList();
+        doReturn(typedQuery).when(manager).createQuery(anyString(),any(Class.class));
+        //when
+        repository.findList(Address.class,"the query as string",Collections.<String, Serializable>emptyMap(),0,10);
+        //then exception
+    }
+
+    @Test(expected = SRetryableException.class)
+    public void should_persist_throw_retryable_exception_in_case_of_persistenceException() throws Exception {
+        //given
+        doThrow(PersistenceException.class).when(manager).persist(any(Address.class));
+        //when
+        repository.persist(new Address(12));
+        //then exception
+    }
+
+    @Test(expected = SRetryableException.class)
+    public void should_merge_throw_retryable_exception_in_case_of_persistenceException() throws Exception {
+        //given
+        doThrow(PersistenceException.class).when(manager).merge(any(Address.class));
+        //when
+        repository.merge(new Address(12));
+        //then exception
+    }
+
+    @Test(expected = SRetryableException.class)
+    public void should_remove_throw_retryable_exception_in_case_of_persistenceException() throws Exception {
+        //given
+        doThrow(PersistenceException.class).when(manager).remove(any(Address.class));
+        //when
+        repository.remove(new Address(12));
+        //then exception
     }
 
     class Address implements Entity {

--- a/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImplTest.java
+++ b/services/bonita-business-data/bonita-business-data-impl/src/test/java/org/bonitasoft/engine/business/data/impl/JsonBusinessDataSerializerImplTest.java
@@ -14,6 +14,7 @@
 package org.bonitasoft.engine.business.data.impl;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssert.assertThatJson;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
+import org.bonitasoft.engine.classloader.ClassLoaderService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,9 +41,11 @@ public class JsonBusinessDataSerializerImplTest {
 
     List<Entity> personList;
 
+    private ClassLoaderService classLoaderService = mock(ClassLoaderService.class);
+
     @Before
     public void setUp() throws Exception {
-        jsonBusinessDataSerializer = new JsonBusinessDataSerializerImpl();
+        jsonBusinessDataSerializer = new JsonBusinessDataSerializerImpl(classLoaderService);
 
     }
 


### PR DESCRIPTION
In order to be able to retrieve from error generated from the BDR
reloading (concurency) persistence exception thrown by the entity
manager are now converted to retryable exception, this way the
transaction manager is able to retry the transaction
