### PR TITLE
BS-14869 Support of null values in contract input validation for lists

### DIFF
--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/DocumentAPIImpl.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/DocumentAPIImpl.java
@@ -203,9 +203,7 @@ public class DocumentAPIImpl implements DocumentAPI {
         final DocumentService documentService = tenantAccessor.getDocumentService();
         try {
             return ModelConvertor.toDocument(documentService.getMappedDocument(documentId), documentService);
-        } catch (final SObjectNotFoundException e) {
-            throw new DocumentNotFoundException(e);
-        } catch (final SBonitaReadException e) {
+        } catch (final SObjectNotFoundException | SBonitaReadException e) {
             throw new DocumentNotFoundException(e);
         }
     }
@@ -250,10 +248,8 @@ public class DocumentAPIImpl implements DocumentAPI {
         final DocumentService documentService = tenantAccessor.getDocumentService();
         try {
             return ModelConvertor.toDocument(documentService.getMappedDocument(processInstanceId, documentName), documentService);
-        } catch (final SObjectNotFoundException sbe) {
+        } catch (final SObjectNotFoundException | SBonitaReadException sbe) {
             throw new DocumentNotFoundException(sbe);
-        } catch (final SBonitaReadException e) {
-            throw new DocumentNotFoundException(e);
         }
     }
 

--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/bpm/contract/validation/ContractStructureValidator.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/bpm/contract/validation/ContractStructureValidator.java
@@ -40,7 +40,7 @@ public class ContractStructureValidator {
 
     public void validate(final SContractDefinition contract, final Map<String, Serializable> inputs) throws SContractViolationException {
         final ErrorReporter errorReporter = new ErrorReporter();
-        validateInputContainer(contract, inputs != null ? inputs : Collections.<String, Serializable> emptyMap(), errorReporter);
+        validateInputContainer(contract, inputs, errorReporter);
         if (errorReporter.hasError()) {
             throw new SContractViolationException("Error while validating expected inputs", errorReporter.getErrors());
         }
@@ -50,7 +50,7 @@ public class ContractStructureValidator {
         logInputsWhichAreNotInContract(DEBUG, inputContainer.getInputDefinitions(), inputs);
         for (final SInputDefinition inputDefinition : inputContainer.getInputDefinitions()) {
             // For each input, fills the errorReporter if some rule is not valid:
-            validateInput(inputs, errorReporter, inputDefinition);
+            validateInput(inputs != null ? inputs : Collections.<String, Serializable> emptyMap(), errorReporter, inputDefinition);
         }
     }
 
@@ -68,7 +68,10 @@ public class ContractStructureValidator {
         if (inputDefinition.hasChildren() && inputDefinition.getType() == null) {
             if (inputDefinition.isMultiple()) {
                 for (final Map<String, Serializable> complexItem : (List<Map<String, Serializable>>) inputs.get(inputDefinition.getName())) {
-                    validateInputContainer(inputDefinition, complexItem, errorReporter);
+                    // we tolerate (and ignore) null values in lists:
+                    if (complexItem != null) {
+                        validateInputContainer(inputDefinition, complexItem, errorReporter);
+                    }
                 }
             } else {
                 validateInputContainer(inputDefinition, (Map<String, Serializable>) inputs.get(inputDefinition.getName()), errorReporter);

--- a/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/bpm/contract/validation/builder/MapBuilder.java
+++ b/bpm/bonita-core/bonita-process-engine/src/test/java/org/bonitasoft/engine/bpm/contract/validation/builder/MapBuilder.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableMap.Builder;
 public class MapBuilder {
 
     public static Builder<String, Serializable> aMap() {
-        return ImmutableMap.<String, Serializable> builder();
+        return ImmutableMap.builder();
     }
 
     public static Map<String, Serializable> contractInputMap(final MapEntry... entries) {


### PR DESCRIPTION
Eg. in the case of given inputs:
{"facture":{"lignes":[null]}}
the validation succeeds and the NULL is just ignored.

We validated with Nicolas the funtional behaviour.