### PR TITLE
BS-14697, fix start process exceptions on contract

### DIFF
--- a/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/activity/ContractIT.java
+++ b/bonita-integration-tests/bonita-integration-tests-client/src/main/java/org/bonitasoft/engine/activity/ContractIT.java
@@ -115,6 +115,14 @@ public class ContractIT extends CommonAPIIT {
         final HashMap<Object, Object> map = new HashMap<>();
         map.put("text", "textValue");
         inputs.put("complex", map);
+        //check exception on contract violation
+        try {
+            getProcessAPI().startProcessWithInputs(processDefinition.getId(), Collections.<String, Serializable> emptyMap());
+            fail("Should throw a contract violation exception");
+        } catch (ContractViolationException e) {
+            assertThat(e.getMessage()).contains("multipleText", "complex");
+        }
+        //start with right inputs
         final ProcessInstance processInstance = getProcessAPI().startProcessWithInputs(processDefinition.getId(), inputs);
         waitForUserTask(processInstance, TASK1);
         final DataInstance processDataValueInitializedFromInput = getProcessAPI().getProcessDataInstance("nbDaysProcessData", processInstance.getId());
@@ -144,8 +152,10 @@ public class ContractIT extends CommonAPIIT {
 
         final ProcessDefinition processDefinition = deployAndEnableProcessWithActor(builder.done(), ACTOR_NAME, matti);
 
-        final ProcessInstance processInstance = getProcessAPI().startProcessWithInputs(processDefinition.getId(), Collections.<String, Serializable>singletonMap("nameInput", "john"));
-        assertThat(getProcessAPI().getProcessDataInstance("name", processInstance.getId()).getValue()).as("value of the data 'name' of the process").isEqualTo("john");
+        final ProcessInstance processInstance = getProcessAPI().startProcessWithInputs(processDefinition.getId(),
+                Collections.<String, Serializable> singletonMap("nameInput", "john"));
+        assertThat(getProcessAPI().getProcessDataInstance("name", processInstance.getId()).getValue()).as("value of the data 'name' of the process")
+                .isEqualTo("john");
         waitForUserTask(TASK1);
 
         getProcessAPI().sendSignal("*Bip Bip*");
@@ -207,7 +217,7 @@ public class ContractIT extends CommonAPIIT {
         //when
         final ProcessDefinition processDefinition = deployAndEnableProcessWithActor(builder.done(), ACTOR_NAME, matti);
         final ProcessInstance processInstance = getProcessAPI().startProcessWithInputs(processDefinition.getId(),
-                Collections.<String, Serializable>singletonMap("reportInit", new FileInputValue("theFile", "", "theContent".getBytes())));
+                Collections.<String, Serializable> singletonMap("reportInit", new FileInputValue("theFile", "", "theContent".getBytes())));
         final HumanTaskInstance userTask = waitForUserTaskAndGetIt(TASK1);
 
         //then
@@ -395,7 +405,8 @@ public class ContractIT extends CommonAPIIT {
         disableAndDeleteProcess(processDefinition);
     }
 
-    private Map<String, Serializable> createExpenseLine(final String expenseType, final float expenseAmount, final Date expenseDate, final byte[] expenseProof) {
+    private Map<String, Serializable> createExpenseLine(final String expenseType, final float expenseAmount, final Date expenseDate,
+            final byte[] expenseProof) {
         final Map<String, Serializable> expenseLine = new HashMap<>();
         expenseLine.put("expenseType", expenseType);
         expenseLine.put("expenseAmount", expenseAmount);

--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/ProcessAPIImpl.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/ProcessAPIImpl.java
@@ -3047,11 +3047,7 @@ public class ProcessAPIImpl implements ProcessAPI {
     @Override
     public ProcessInstance startProcessWithInputs(final long userId, final long processDefinitionId, final Map<String, Serializable> instantiationInputs)
             throws ProcessDefinitionNotFoundException, ProcessActivationException, ProcessExecutionException, ContractViolationException {
-        try {
             return new ProcessStarter(userId, processDefinitionId, instantiationInputs).start();
-        } catch (SContractViolationException e) {
-            throw new ContractViolationException(e.getSimpleMessage(), e.getMessage(), e.getExplanations(), e.getCause());
-        }
     }
 
     @Override
@@ -3104,9 +3100,9 @@ public class ProcessAPIImpl implements ProcessAPI {
         final ProcessStarter starter = new ProcessStarter(userId, processDefinitionId, operations, context);
         try {
             return starter.start();
-        } catch (SContractViolationException e) {
+        } catch (ContractViolationException e) {
             // To not have an API break, we need to wrapped this new Exception:
-            throw new ProcessExecutionException(new ContractViolationException(e.getSimpleMessage(), e.getMessage(), e.getExplanations(), e.getCause()));
+            throw new ProcessExecutionException(e);
         }
     }
 

--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/ProcessStarter.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/api/impl/ProcessStarter.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.bonitasoft.engine.bpm.connector.ConnectorDefinitionWithInputValues;
+import org.bonitasoft.engine.bpm.contract.ContractViolationException;
 import org.bonitasoft.engine.bpm.process.ProcessActivationException;
 import org.bonitasoft.engine.bpm.process.ProcessDefinitionNotFoundException;
 import org.bonitasoft.engine.bpm.process.ProcessExecutionException;
@@ -96,10 +97,11 @@ public class ProcessStarter {
         this(userId, processDefinitionId, null, null, new StartFlowNodeFilter(), instantiationInputs);
     }
 
-    public ProcessInstance start() throws ProcessDefinitionNotFoundException, ProcessActivationException, ProcessExecutionException,
-            SContractViolationException {
+    public ProcessInstance start() throws ProcessDefinitionNotFoundException, ProcessActivationException, ProcessExecutionException, ContractViolationException {
         try {
             return start(null);
+        } catch (final SContractViolationException e) {
+            throw new ContractViolationException(e.getSimpleMessage(), e.getMessage(), e.getExplanations(), e.getCause());
         } catch (final SProcessDefinitionNotFoundException e) {
             throw new ProcessDefinitionNotFoundException(e);
         } catch (final SBonitaReadException e) {
@@ -113,7 +115,7 @@ public class ProcessStarter {
 
     // For commands
     public ProcessInstance start(final List<ConnectorDefinitionWithInputValues> connectorsWithInput) throws SProcessInstanceCreationException,
-            SBonitaReadException, SProcessDefinitionException {
+            SBonitaReadException, SProcessDefinitionException, SContractViolationException {
         final TenantServiceAccessor tenantAccessor = getTenantAccessor();
         final ProcessExecutor processExecutor = tenantAccessor.getProcessExecutor();
         final ProcessDefinitionService processDefinitionService = tenantAccessor.getProcessDefinitionService();

--- a/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/command/AbstractStartProcessCommand.java
+++ b/bpm/bonita-core/bonita-process-engine/src/main/java/org/bonitasoft/engine/command/AbstractStartProcessCommand.java
@@ -18,13 +18,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.bonitasoft.engine.api.impl.ProcessStarter;
+import org.bonitasoft.engine.bpm.contract.ContractViolationException;
 import org.bonitasoft.engine.bpm.process.ProcessActivationException;
 import org.bonitasoft.engine.bpm.process.ProcessDefinitionNotFoundException;
 import org.bonitasoft.engine.bpm.process.ProcessExecutionException;
 import org.bonitasoft.engine.bpm.process.ProcessInstance;
 import org.bonitasoft.engine.command.system.CommandWithParameters;
 import org.bonitasoft.engine.commons.exceptions.SBonitaException;
-import org.bonitasoft.engine.core.process.instance.api.exceptions.SContractViolationException;
 import org.bonitasoft.engine.execution.AdvancedStartProcessValidator;
 import org.bonitasoft.engine.operation.Operation;
 import org.bonitasoft.engine.service.TenantServiceAccessor;
@@ -62,7 +62,7 @@ public abstract class AbstractStartProcessCommand extends CommandWithParameters 
 
     private ProcessInstance startProcess(final long processDefinitionId, final List<String> activityNames, final long startedBy,
             final Map<String, Serializable> context, final List<Operation> operations) throws ProcessDefinitionNotFoundException, ProcessActivationException,
-            ProcessExecutionException, SContractViolationException {
+            ProcessExecutionException, ContractViolationException {
         final ProcessStarter starter = new ProcessStarter(startedBy, processDefinitionId, operations, context, activityNames);
         return starter.start();
     }

--- a/bpm/bonita-core/bonita-process-instance/bonita-process-instance-api/src/main/java/org/bonitasoft/engine/core/process/instance/api/exceptions/SContractViolationException.java
+++ b/bpm/bonita-core/bonita-process-instance/bonita-process-instance-api/src/main/java/org/bonitasoft/engine/core/process/instance/api/exceptions/SContractViolationException.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.bonitasoft.engine.persistence.SBonitaReadException;
+import org.bonitasoft.engine.commons.exceptions.SBonitaException;
 
 /**
  * Thrown when the {@link org.bonitasoft.engine.core.process.definition.model.SContractDefinition} is not fulfilled.
@@ -25,7 +25,7 @@ import org.bonitasoft.engine.persistence.SBonitaReadException;
  * @author Emmanuel Duchastenier
  * @since 7.0
  */
-public class SContractViolationException extends SBonitaReadException {
+public class SContractViolationException extends SBonitaException {
 
     private final List<String> explanations;
     private final String simpleMessage;


### PR DESCRIPTION
startProcessWithInputs now throw SContractViolationException, before it
was throwing Retrieve Exception because of a wrong catch and convertion
of server/client exceptions