### PR TITLE
fix (platform-setup): Prevents special regex characters from interferring with database configuration

### DIFF
--- a/platform/platform-setup/src/main/java/org/bonitasoft/platform/setup/command/configure/BundleConfigurator.java
+++ b/platform/platform-setup/src/main/java/org/bonitasoft/platform/setup/command/configure/BundleConfigurator.java
@@ -148,7 +148,7 @@ abstract class BundleConfigurator {
 
     String replaceValues(String content, Map<String, String> replacementMap) throws PlatformException {
         for (Map.Entry<String, String> entry : replacementMap.entrySet()) {
-            content = replace(content, entry.getKey(), convertWindowsBackslashes(entry.getValue()));
+            content = replace(content, entry.getKey(), entry.getValue());
         }
         return content;
     }
@@ -243,6 +243,7 @@ abstract class BundleConfigurator {
     }
 
     private String replace(String content, String originalValue, String replacement) {
+        LOGGER.debug("Replacing '" + originalValue + "' with '" + replacement + "'");
         return content.replaceAll(originalValue, replacement);
     }
 

--- a/platform/platform-setup/src/main/java/org/bonitasoft/platform/setup/command/configure/TomcatBundleConfigurator.java
+++ b/platform/platform-setup/src/main/java/org/bonitasoft/platform/setup/command/configure/TomcatBundleConfigurator.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
 
 import org.bonitasoft.platform.exception.PlatformException;
 
@@ -101,18 +102,18 @@ class TomcatBundleConfigurator extends BundleConfigurator {
 
     private String updateBitronixFile(String content, DatabaseConfiguration configuration, final String bitronixDatasourceAlias) throws PlatformException {
         Map<String, String> replacements = new HashMap<>(7);
-        replacements.put("@@" + bitronixDatasourceAlias + "_driver_class_name@@", configuration.getXaDriverClassName());
-        replacements.put("@@" + bitronixDatasourceAlias + "_database_connection_user@@", configuration.getDatabaseUser());
-        replacements.put("@@" + bitronixDatasourceAlias + "_database_connection_password@@", configuration.getDatabasePassword());
-        replacements.put("@@" + bitronixDatasourceAlias + "_database_test_query@@", configuration.getTestQuery());
+        replacements.put("@@" + bitronixDatasourceAlias + "_driver_class_name@@", Matcher.quoteReplacement(configuration.getXaDriverClassName()));
+        replacements.put("@@" + bitronixDatasourceAlias + "_database_connection_user@@", Matcher.quoteReplacement(configuration.getDatabaseUser()));
+        replacements.put("@@" + bitronixDatasourceAlias + "_database_connection_password@@", Matcher.quoteReplacement(configuration.getDatabasePassword()));
+        replacements.put("@@" + bitronixDatasourceAlias + "_database_test_query@@", Matcher.quoteReplacement(configuration.getTestQuery()));
 
         // Let's uncomment and replace dbvendor-specific values:
         if (POSTGRES.equals(configuration.getDbVendor())) {
-            replacements.putAll(uncommentLineAndReplace("@@" + bitronixDatasourceAlias + "_postgres_server_name@@", configuration.getServerName()));
-            replacements.putAll(uncommentLineAndReplace("@@" + bitronixDatasourceAlias + "_postgres_port_number@@", configuration.getServerPort()));
-            replacements.putAll(uncommentLineAndReplace("@@" + bitronixDatasourceAlias + "_postgres_database_name@@", configuration.getDatabaseName()));
+            replacements.putAll(uncommentLineAndReplace("@@" + bitronixDatasourceAlias + "_postgres_server_name@@", Matcher.quoteReplacement(configuration.getServerName())));
+            replacements.putAll(uncommentLineAndReplace("@@" + bitronixDatasourceAlias + "_postgres_port_number@@", Matcher.quoteReplacement(configuration.getServerPort())));
+            replacements.putAll(uncommentLineAndReplace("@@" + bitronixDatasourceAlias + "_postgres_database_name@@", Matcher.quoteReplacement(configuration.getDatabaseName())));
         } else {
-            replacements.putAll(uncommentLineAndReplace("@@" + bitronixDatasourceAlias + "_database_connection_url@@", configuration.getUrl()));
+            replacements.putAll(uncommentLineAndReplace("@@" + bitronixDatasourceAlias + "_database_connection_url@@", Matcher.quoteReplacement(convertWindowsBackslashes(configuration.getUrl()))));
         }
 
         return replaceValues(content, replacements);
@@ -124,17 +125,17 @@ class TomcatBundleConfigurator extends BundleConfigurator {
 
     private String updateBonitaXmlFile(String content, DatabaseConfiguration configuration, final String bitronixDatasourceAlias) throws PlatformException {
         Map<String, String> replacements = new HashMap<>(5);
-        replacements.put("@@" + bitronixDatasourceAlias + ".database_connection_user@@", configuration.getDatabaseUser());
-        replacements.put("@@" + bitronixDatasourceAlias + ".database_connection_password@@", configuration.getDatabasePassword());
-        replacements.put("@@" + bitronixDatasourceAlias + ".driver_class_name@@", configuration.getNonXaDriverClassName());
-        replacements.put("@@" + bitronixDatasourceAlias + ".database_connection_url@@", escapeXmlCharacters(configuration.getUrl()));
-        replacements.put("@@" + bitronixDatasourceAlias + ".database_test_query@@", configuration.getTestQuery());
+        replacements.put("@@" + bitronixDatasourceAlias + ".database_connection_user@@", Matcher.quoteReplacement(configuration.getDatabaseUser()));
+        replacements.put("@@" + bitronixDatasourceAlias + ".database_connection_password@@", Matcher.quoteReplacement(configuration.getDatabasePassword()));
+        replacements.put("@@" + bitronixDatasourceAlias + ".driver_class_name@@", Matcher.quoteReplacement(configuration.getNonXaDriverClassName()));
+        replacements.put("@@" + bitronixDatasourceAlias + ".database_connection_url@@", Matcher.quoteReplacement(escapeXmlCharacters(convertWindowsBackslashes(configuration.getUrl()))));
+        replacements.put("@@" + bitronixDatasourceAlias + ".database_test_query@@", Matcher.quoteReplacement(configuration.getTestQuery()));
         return replaceValues(content, replacements);
     }
 
     private String updateSetEnvFile(String setEnvFileContent, String dbVendor, final String systemPropertyName) throws PlatformException {
         final Map<String, String> replacementMap = Collections.singletonMap("-D" + systemPropertyName + "=.*\"",
-                "-D" + systemPropertyName + "=" + dbVendor + "\"");
+                Matcher.quoteReplacement("-D" + systemPropertyName + "=" + dbVendor + "\""));
 
         return replaceValues(setEnvFileContent, replacementMap);
     }

--- a/platform/platform-setup/src/main/java/org/bonitasoft/platform/setup/command/configure/WildflyBundleConfigurator.java
+++ b/platform/platform-setup/src/main/java/org/bonitasoft/platform/setup/command/configure/WildflyBundleConfigurator.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
 
 import org.bonitasoft.platform.exception.PlatformException;
 
@@ -115,35 +116,35 @@ class WildflyBundleConfigurator extends BundleConfigurator {
 
     private String updateModuleFile(String moduleFileContent, DatabaseConfiguration configuration, Path driverFilename) throws PlatformException {
         Map<String, String> replacements = new HashMap<>(2);
-        replacements.put("@@MODULE_NAME@@", wildflyModules.get(configuration.getDbVendor()).replaceAll("/", "."));
-        replacements.put("@@DRIVERFILE_NAME@@", driverFilename.getFileName().toString());
+        replacements.put("@@MODULE_NAME@@", Matcher.quoteReplacement(wildflyModules.get(configuration.getDbVendor()).replaceAll("/", ".")));
+        replacements.put("@@DRIVERFILE_NAME@@", Matcher.quoteReplacement(convertWindowsBackslashes(driverFilename.getFileName().toString())));
         return replaceValues(moduleFileContent, replacements);
     }
 
     private String updateStandaloneXmlFile(String content, DatabaseConfiguration configuration, final String databasePrefix) throws PlatformException {
         Map<String, String> replacements = new HashMap<>(12);
 
-        replacements.put("@@" + databasePrefix + "MODULE_NAME@@", wildflyModules.get(configuration.getDbVendor()).replaceAll("/", "."));
-        replacements.put("@@" + databasePrefix + "XA_DRIVER_CLASSNAME@@", configuration.getXaDriverClassName());
+        replacements.put("@@" + databasePrefix + "MODULE_NAME@@", Matcher.quoteReplacement(wildflyModules.get(configuration.getDbVendor()).replaceAll("/", ".")));
+        replacements.put("@@" + databasePrefix + "XA_DRIVER_CLASSNAME@@", Matcher.quoteReplacement(configuration.getXaDriverClassName()));
 
         // We can have only once a driver declaration for each DB Vendor:
         if (!standardConfiguration.getDbVendor().equals(bdmConfiguration.getDbVendor())) {
             replacements.put("<!-- BDM_DRIVER_TEMPLATE (.*) BDM_DRIVER_TEMPLATE -->", "<$1>");
         }
 
-        replacements.put("@@" + databasePrefix + "DB_VENDOR@@", configuration.getDbVendor());
-        replacements.put("@@" + databasePrefix + "USERNAME@@", configuration.getDatabaseUser());
-        replacements.put("@@" + databasePrefix + "PASSWORD@@", configuration.getDatabasePassword());
-        replacements.put("@@" + databasePrefix + "TESTQUERY@@", configuration.getTestQuery());
-        replacements.put("<connection-url>@@" + databasePrefix + "DB_URL@@", "<connection-url>" + escapeXmlCharacters(configuration.getUrl()));
+        replacements.put("@@" + databasePrefix + "DB_VENDOR@@", Matcher.quoteReplacement(configuration.getDbVendor()));
+        replacements.put("@@" + databasePrefix + "USERNAME@@", Matcher.quoteReplacement(configuration.getDatabaseUser()));
+        replacements.put("@@" + databasePrefix + "PASSWORD@@", Matcher.quoteReplacement(configuration.getDatabasePassword()));
+        replacements.put("@@" + databasePrefix + "TESTQUERY@@", Matcher.quoteReplacement(configuration.getTestQuery()));
+        replacements.put("<connection-url>@@" + databasePrefix + "DB_URL@@", "<connection-url>" + convertWindowsBackslashes(escapeXmlCharacters(configuration.getUrl())));
 
         // Let's uncomment and replace dbvendor-specific values:
         if (POSTGRES.equals(configuration.getDbVendor())) {
-            replacements.putAll(uncommentXmlLineAndReplace("@@" + databasePrefix + "DB_SERVER_NAME@@", configuration.getServerName()));
-            replacements.putAll(uncommentXmlLineAndReplace("@@" + databasePrefix + "DB_SERVER_PORT@@", configuration.getServerPort()));
-            replacements.putAll(uncommentXmlLineAndReplace("@@" + databasePrefix + "DB_DATABASE_NAME@@", configuration.getDatabaseName()));
+            replacements.putAll(uncommentXmlLineAndReplace("@@" + databasePrefix + "DB_SERVER_NAME@@", Matcher.quoteReplacement(configuration.getServerName())));
+            replacements.putAll(uncommentXmlLineAndReplace("@@" + databasePrefix + "DB_SERVER_PORT@@", Matcher.quoteReplacement(configuration.getServerPort())));
+            replacements.putAll(uncommentXmlLineAndReplace("@@" + databasePrefix + "DB_DATABASE_NAME@@", Matcher.quoteReplacement(configuration.getDatabaseName())));
         } else {
-            replacements.putAll(uncommentXmlLineAndReplace("@@" + databasePrefix + "DB_URL@@", escapeXmlCharacters(configuration.getUrl())));
+            replacements.putAll(uncommentXmlLineAndReplace("@@" + databasePrefix + "DB_URL@@", Matcher.quoteReplacement(escapeXmlCharacters(convertWindowsBackslashes(configuration.getUrl())))));
         }
         if (ORACLE.equals(configuration.getDbVendor())) {
             replacements.putAll(uncommentXmlLineAndReplace("@@" + databasePrefix + "IS_SAME_RM_OVERRIDE@@", "false"));//forced to false


### PR DESCRIPTION
While trying to setup Bonita using a PostgreSQL database, I came across the following error:

```java
------------------------------------------------------
Initializing and configuring Bonita BPM WildFly bundle
------------------------------------------------------
 ____              _ _          ____  _____  __  __
|  _ \            (_) |        |  _ \|  __ \|  \/  |
| |_) | ___  _ __  _| |_ __ _  | |_) | |__) | \  / |
|  _ < / _ \| '_ \| | __/ _` | |  _ <|  ___/| |\/| |
| |_) | (_) | | | | | || (_| | | |_) | |    | |  | |
|____/ \___/|_| |_|_|\__\__,_| |____/|_|    |_|  |_|

(platform Setup 7.4.3)

[INFO] configuration for Database vendor: postgres
[INFO] Connected to 'postgres' database with url: 'jdbc:postgresql://localhost:5436/BonitaBPM' with user: 'postgres'
[INFO] Executed SQL script /home/dtoupin/wildfly-DEV/BonitaBPMCommunity-7.4.3-wildfly-10.1.0.Final/setup/platform_conf/sql/postgres/createTables.sql
[INFO] Executed SQL script /home/dtoupin/wildfly-DEV/BonitaBPMCommunity-7.4.3-wildfly-10.1.0.Final/setup/platform_conf/sql/postgres/createQuartzTables.sql
[INFO] Executed SQL script /home/dtoupin/wildfly-DEV/BonitaBPMCommunity-7.4.3-wildfly-10.1.0.Final/setup/platform_conf/sql/postgres/postCreateStructure.sql
[INFO] Executed SQL script /home/dtoupin/wildfly-DEV/BonitaBPMCommunity-7.4.3-wildfly-10.1.0.Final/setup/platform_conf/sql/postgres/initTables.sql
[INFO] Platform created.
[INFO] Database will be initialized with configuration files from folder: platform_conf/initial
[INFO] Initial configuration files successfully pushed to database
[INFO] Wildfly environment detected with root /home/dtoupin/wildfly-DEV/BonitaBPMCommunity-7.4.3-wildfly-10.1.0.Final
[INFO] Running auto-configuration using file /home/dtoupin/wildfly-DEV/BonitaBPMCommunity-7.4.3-wildfly-10.1.0.Final/setup/database.properties
[ERROR] No group 3
[ERROR] You might get more detailed information about the error by setting 'org.bonitasoft.platform.setup.PlatformSetupApplication' log level to 'DEBUG' in file 'logback.xml' and run again
```
The error puzzled me and after enabling the debug logging level, I finally understood what was going on:
```java
[DEBUG] ERROR: 
java.lang.IndexOutOfBoundsException: No group 3
	at java.util.regex.Matcher.start(Matcher.java:375) ~[na:1.8.0_121]
	at java.util.regex.Matcher.appendReplacement(Matcher.java:880) ~[na:1.8.0_121]
	at java.util.regex.Matcher.replaceAll(Matcher.java:955) ~[na:1.8.0_121]
	at java.lang.String.replaceAll(String.java:2223) ~[na:1.8.0_121]
	at org.bonitasoft.platform.setup.command.configure.BundleConfigurator.replace(BundleConfigurator.java:246) ~[platform-setup-7.4.3.jar:na]
	at org.bonitasoft.platform.setup.command.configure.BundleConfigurator.replaceValues(BundleConfigurator.java:151) ~[platform-setup-7.4.3.jar:na]
	at org.bonitasoft.platform.setup.command.configure.WildflyBundleConfigurator.updateStandaloneXmlFile(WildflyBundleConfigurator.java:149) ~[platform-setup-7.4.3.jar:na]
	at org.bonitasoft.platform.setup.command.configure.WildflyBundleConfigurator.configureApplicationServer(WildflyBundleConfigurator.java:69) ~[platform-setup-7.4.3.jar:na]
	at org.bonitasoft.platform.setup.command.configure.ConfigureCommand.execute(ConfigureCommand.java:37) ~[platform-setup-7.4.3.jar:na]
	at org.bonitasoft.platform.setup.PlatformSetupApplication.execute(PlatformSetupApplication.java:105) [platform-setup-7.4.3.jar:na]
	at org.bonitasoft.platform.setup.PlatformSetupApplication.run(PlatformSetupApplication.java:79) [platform-setup-7.4.3.jar:na]
	at org.bonitasoft.platform.setup.PlatformSetupApplication.main(PlatformSetupApplication.java:64) [platform-setup-7.4.3.jar:na]
```
The issue is that my tool-generated password uses a dollar-sign followed by a number (in this case 3) and this has a special meaning to `String::replaceAll`.

My fix therefore protect values coming the database configuration against a misinterpretation.