### PR TITLE
poc(travis): openjdk8 on xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 os: linux
-dist: trusty
+dist: xenial
 
 script: ./gradlew -q test
 


### PR DESCRIPTION
Bonita 7.10 supports Ubuntu 18.x, try to upgrade to a closest version (Ubuntu 16 instead of Ubuntu 14)