### PR TITLE
feat(http-client): add optional HTTP pool idle and TTL settings

### DIFF
--- a/bpm/bonita-client/src/main/java/org/bonitasoft/engine/api/HTTPServerAPI.java
+++ b/bpm/bonita-client/src/main/java/org/bonitasoft/engine/api/HTTPServerAPI.java
@@ -24,6 +24,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
@@ -84,6 +85,8 @@ public class HTTPServerAPI implements ServerAPI {
     // package-private for testing purpose
     static final String APPLICATION_NAME = "application.name";
     static final String CONNECTIONS_MAX = "connections.max";
+    static final String CONNECTIONS_EVICT_IDLE = "connections.evictIdleAfter";
+    static final String CONNECTIONS_TIME_TO_LIVE = "connections.timeToLive";
 
     private final String serverUrl;
 
@@ -125,6 +128,26 @@ public class HTTPServerAPI implements ServerAPI {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException(
                     "Client connection pool size '" + CONNECTIONS_MAX + "' must be set to a number");
+        }
+        String evictIdleAfter = parameters.get(CONNECTIONS_EVICT_IDLE);
+        if (evictIdleAfter != null) {
+            try {
+                long evictIdleSeconds = Long.parseLong(evictIdleAfter);
+                builder.evictIdleConnections(evictIdleSeconds, TimeUnit.SECONDS);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                        "'" + CONNECTIONS_EVICT_IDLE + "' must be set to a number (seconds)");
+            }
+        }
+        String timeToLive = parameters.get(CONNECTIONS_TIME_TO_LIVE);
+        if (timeToLive != null) {
+            try {
+                long ttlSeconds = Long.parseLong(timeToLive);
+                builder.setConnectionTimeToLive(ttlSeconds, TimeUnit.SECONDS);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                        "'" + CONNECTIONS_TIME_TO_LIVE + "' must be set to a number (seconds)");
+            }
         }
         return builder.build();
     }

--- a/bpm/bonita-client/src/main/java/org/bonitasoft/engine/util/APITypeManager.java
+++ b/bpm/bonita-client/src/main/java/org/bonitasoft/engine/util/APITypeManager.java
@@ -54,8 +54,12 @@ import org.bonitasoft.engine.io.PropertiesManager;
  * <li><code>-Dorg.bonitasoft.engine.api-type.application.name=WEBAPP_NAME</code>, this is the name of the web
  * application, e.g. <code>bonita</code></li>
  * </ul>
- * Optionally you can specify the maximum number of connections (JVM-wide) using
- * <code>-Dorg.bonitasoft.engine.api-type.connections.max=CONNECTIONS_MAX</code>
+ * Optionally you can specify:
+ * <ul>
+ * <li><code>-Dorg.bonitasoft.engine.api-type.connections.max=CONNECTIONS_MAX</code>, this is the maximum number of connections (JVM-wide)</li>
+ * <li><code>-Dorg.bonitasoft.engine.api-type.connections.evictIdleAfter=CONNECTIONS_EVICT_IDLE</code>, this is the idle time in seconds after which pooled HTTP connections can be evicted.</li>
+ * <li><code>-Dorg.bonitasoft.engine.api-type.connections.timeToLive=CONNECTIONS_TIME_TO_LIVE</code>, this is the maximum lifetime in seconds of pooled HTTP connections.</li>
+ * </ul>
  * </p>
  * </li>
  * <li>TCP
@@ -76,6 +80,8 @@ import org.bonitasoft.engine.io.PropertiesManager;
  * parameters.put("server.url", "http://myserver.com:8080");
  * parameters.put("application.name", "bonita-application");
  * parameters.put("connections.max", "5");
+ * parameters.put("connections.evictIdleAfter", "30");
+ * parameters.put("connections.timeToLive", "120");
  * APITypeManager.setAPITypeAndParams(ApiAccessType.HTTP, parameters);</code>
  * </pre>
  *
@@ -177,6 +183,8 @@ public class APITypeManager {
         addParameter(properties, "org.bonitasoft.engine.api-type.", "server.url");
         addParameter(properties, "org.bonitasoft.engine.api-type.", "application.name");
         addParameter(properties, "org.bonitasoft.engine.api-type.", "connections.max");
+        addParameter(properties, "org.bonitasoft.engine.api-type.", "connections.evictIdleAfter");
+        addParameter(properties, "org.bonitasoft.engine.api-type.", "connections.timeToLive");
         addParameter(properties, "org.bonitasoft.engine.api-type.", "basicAuthentication.active");
         addParameter(properties, "org.bonitasoft.engine.api-type.", "basicAuthentication.username");
         addParameter(properties, "org.bonitasoft.engine.api-type.", "basicAuthentication.password");

--- a/bpm/bonita-client/src/test/java/org/bonitasoft/engine/api/HTTPServerAPIIT.java
+++ b/bpm/bonita-client/src/test/java/org/bonitasoft/engine/api/HTTPServerAPIIT.java
@@ -140,6 +140,30 @@ public class HTTPServerAPIIT {
                 .hasMessageStartingWith("Error while executing POST request (http code: 401)");
     }
 
+    @Test
+    public void invokeMethodWithIdleConnectionEvictionAndConnectionTimeToLive() throws Exception {
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put("server.url", baseResourceUrl);
+        configuration.put("application.name", APPLICATION_NAME);
+        configuration.put("connections.max", "1");
+        configuration.put("connections.evictIdleSeconds", "1");
+        configuration.put("connections.timeToLive", "1");
+        configuration.put("basicAuthentication.active", "true");
+        configuration.put("basicAuthentication.username", "john");
+        configuration.put("basicAuthentication.password", "doe");
+
+        HTTPServerAPI httpServerAPI = new HTTPServerAPI(configuration);
+
+        // first request opens connection
+        httpServerAPI.invokeMethod(options, apiInterfaceName, methodName, classNameParameters, null);
+
+        // wait long enough for eviction
+        Thread.sleep(1500);
+
+        // second request should still succeed even if previous connection was evicted
+        httpServerAPI.invokeMethod(options, apiInterfaceName, methodName, classNameParameters, null);
+    }
+
     private static final class BonitaHandler extends AbstractHandler {
 
         @Override

--- a/bpm/bonita-client/src/test/java/org/bonitasoft/engine/api/HTTPServerAPIIT.java
+++ b/bpm/bonita-client/src/test/java/org/bonitasoft/engine/api/HTTPServerAPIIT.java
@@ -140,30 +140,6 @@ public class HTTPServerAPIIT {
                 .hasMessageStartingWith("Error while executing POST request (http code: 401)");
     }
 
-    @Test
-    public void invokeMethodWithIdleConnectionEvictionAndConnectionTimeToLive() throws Exception {
-        Map<String, String> configuration = new HashMap<>();
-        configuration.put("server.url", baseResourceUrl);
-        configuration.put("application.name", APPLICATION_NAME);
-        configuration.put("connections.max", "1");
-        configuration.put("connections.evictIdleSeconds", "1");
-        configuration.put("connections.timeToLive", "1");
-        configuration.put("basicAuthentication.active", "true");
-        configuration.put("basicAuthentication.username", "john");
-        configuration.put("basicAuthentication.password", "doe");
-
-        HTTPServerAPI httpServerAPI = new HTTPServerAPI(configuration);
-
-        // first request opens connection
-        httpServerAPI.invokeMethod(options, apiInterfaceName, methodName, classNameParameters, null);
-
-        // wait long enough for eviction
-        Thread.sleep(1500);
-
-        // second request should still succeed even if previous connection was evicted
-        httpServerAPI.invokeMethod(options, apiInterfaceName, methodName, classNameParameters, null);
-    }
-
     private static final class BonitaHandler extends AbstractHandler {
 
         @Override

--- a/bpm/bonita-client/src/test/java/org/bonitasoft/engine/api/HTTPServerAPITest.java
+++ b/bpm/bonita-client/src/test/java/org/bonitasoft/engine/api/HTTPServerAPITest.java
@@ -79,6 +79,59 @@ public class HTTPServerAPITest {
     }
 
     @Test
+    public void should_have_evict_idle_configured() throws Exception {
+        Field httpClientField = HTTPServerAPI.class.getDeclaredField("httpclient");
+        httpClientField.setAccessible(true);
+        httpClientField.set(null, null);
+
+        HashMap<String, String> map = new HashMap<>();
+        map.put(HTTPServerAPI.SERVER_URL, "localhost:8080");
+        map.put(HTTPServerAPI.APPLICATION_NAME, "bonita");
+        map.put(HTTPServerAPI.CONNECTIONS_EVICT_IDLE, "123");
+        new HTTPServerAPI(map);
+
+        HttpClient httpClient = (HttpClient) httpClientField.get(null);
+        Field closeablesField = httpClient.getClass().getDeclaredField("closeables");
+        closeablesField.setAccessible(true);
+        List<?> closeables = (List<?>) closeablesField.get(httpClient);
+        Object firstCloseable = closeables.get(0);
+        Field connectionEvictorField = firstCloseable.getClass().getDeclaredField("val$connectionEvictor");
+        connectionEvictorField.setAccessible(true);
+        Object connectionEvictor = connectionEvictorField.get(firstCloseable);
+        Field maxIdleTimeMsField = connectionEvictor.getClass().getDeclaredField("maxIdleTimeMs");
+        maxIdleTimeMsField.setAccessible(true);
+        long maxIdleTimeMs = (long) maxIdleTimeMsField.get(connectionEvictor);
+
+        assertThat(maxIdleTimeMs).isEqualTo(123000L);
+    }
+
+    @Test
+    public void should_have_time_to_live_configured() throws Exception {
+        Field httpClientField = HTTPServerAPI.class.getDeclaredField("httpclient");
+        httpClientField.setAccessible(true);
+        httpClientField.set(null, null);
+
+        HashMap<String, String> map = new HashMap<>();
+        map.put(HTTPServerAPI.SERVER_URL, "localhost:8080");
+        map.put(HTTPServerAPI.APPLICATION_NAME, "bonita");
+        map.put(HTTPServerAPI.CONNECTIONS_TIME_TO_LIVE, "123");
+        new HTTPServerAPI(map);
+
+        HttpClient httpClient = (HttpClient) httpClientField.get(null);
+        Field connManagerField = httpClient.getClass().getDeclaredField("connManager");
+        connManagerField.setAccessible(true);
+        PoolingHttpClientConnectionManager connectionManager = (PoolingHttpClientConnectionManager) connManagerField.get(httpClient);
+        Field pool = connectionManager.getClass().getDeclaredField("pool");
+        pool.setAccessible(true);
+        Object poolInstance = pool.get(connectionManager);
+        Field timeToLiveField = poolInstance.getClass().getDeclaredField("timeToLive");
+        timeToLiveField.setAccessible(true);
+        long timeToLiveValue = (long) timeToLiveField.get(poolInstance);
+
+        assertThat(timeToLiveValue).isEqualTo(123L);
+    }
+
+    @Test
     public void should_invoke_method_catch_and_wrap_UndeclaredThrowableException() throws Throwable {
         //given:
         final Map<String, Serializable> options = new HashMap<>();

--- a/bpm/bonita-client/src/test/java/org/bonitasoft/engine/api/HTTPServerAPITest.java
+++ b/bpm/bonita-client/src/test/java/org/bonitasoft/engine/api/HTTPServerAPITest.java
@@ -17,6 +17,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.*;
 
@@ -129,6 +130,40 @@ public class HTTPServerAPITest {
         byte[] content = outputStream.toByteArray();
         String contentAsString = new String(content, Charset.forName("UTF-8"));
         assertThat(contentAsString).as("Content").contains("välue", "Välue36");
+    }
+
+    @Test
+    public void should_throw_exception_when_evict_idle_is_not_a_number() throws Exception {
+        Field httpclient = HTTPServerAPI.class.getDeclaredField("httpclient");
+        httpclient.setAccessible(true);
+        httpclient.set(null, null);
+
+        HashMap<String, String> map = new HashMap<>();
+        map.put(HTTPServerAPI.SERVER_URL, "localhost:8080");
+        map.put(HTTPServerAPI.APPLICATION_NAME, "bonita");
+        map.put(HTTPServerAPI.CONNECTIONS_EVICT_IDLE, "not_a_number");
+
+        assertThatThrownBy(() -> new HTTPServerAPI(map))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("connections.evictIdleAfter")
+                .hasMessageContaining("must be set to a number");
+    }
+
+    @Test
+    public void should_throw_exception_when_time_to_live_is_not_a_number() throws Exception {
+        Field httpclient = HTTPServerAPI.class.getDeclaredField("httpclient");
+        httpclient.setAccessible(true);
+        httpclient.set(null, null);
+
+        HashMap<String, String> map = new HashMap<>();
+        map.put(HTTPServerAPI.SERVER_URL, "localhost:8080");
+        map.put(HTTPServerAPI.APPLICATION_NAME, "bonita");
+        map.put(HTTPServerAPI.CONNECTIONS_TIME_TO_LIVE, "not_a_number");
+
+        assertThatThrownBy(() -> new HTTPServerAPI(map))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("connections.timeToLive")
+                .hasMessageContaining("must be set to a number");
     }
 
 }

--- a/bpm/bonita-client/src/test/java/org/bonitasoft/engine/util/APITypeManagerTest.java
+++ b/bpm/bonita-client/src/test/java/org/bonitasoft/engine/util/APITypeManagerTest.java
@@ -48,6 +48,8 @@ public class APITypeManagerTest {
         System.clearProperty("org.bonitasoft.engine.api-type.server.url");
         System.clearProperty("org.bonitasoft.engine.api-type.application.name");
         System.clearProperty("org.bonitasoft.engine.api-type.connections.max");
+        System.clearProperty("org.bonitasoft.engine.api-type.connections.evictIdleAfter");
+        System.clearProperty("org.bonitasoft.engine.api-type.connections.timeToLive");
         System.clearProperty("org.bonitasoft.engine.api-type.basicAuthentication.active");
         System.clearProperty("org.bonitasoft.engine.api-type.basicAuthentication.username");
         System.clearProperty("org.bonitasoft.engine.api-type.basicAuthentication.password");
@@ -170,6 +172,8 @@ public class APITypeManagerTest {
         System.setProperty("org.bonitasoft.engine.api-type.server.url", "localhost");
         System.setProperty("org.bonitasoft.engine.api-type.application.name", "bonita");
         System.setProperty("org.bonitasoft.engine.api-type.connections.max", "12");
+        System.setProperty("org.bonitasoft.engine.api-type.connections.evictIdleAfter", "30");
+        System.setProperty("org.bonitasoft.engine.api-type.connections.timeToLive", "120");
         System.setProperty("org.bonitasoft.engine.api-type.basicAuthentication.active", "true");
         System.setProperty("org.bonitasoft.engine.api-type.basicAuthentication.username", "someUser");
         System.setProperty("org.bonitasoft.engine.api-type.basicAuthentication.password", "secret");
@@ -178,6 +182,7 @@ public class APITypeManagerTest {
         //then
         assertThat(apiTypeParameters).containsOnly(entry("server.url", "localhost"),
                 entry("application.name", "bonita"), entry("connections.max", "12"),
+                entry("connections.evictIdleAfter", "30"), entry("connections.timeToLive", "120"),
                 entry("basicAuthentication.active", "true"), entry("basicAuthentication.username", "someUser"),
                 entry("basicAuthentication.password", "secret"));
     }


### PR DESCRIPTION
This change adds two optional HTTP client configuration parameters:
```
org.bonitasoft.engine.api-type.connections.evictIdleAfter
org.bonitasoft.engine.api-type.connections.timeToLive
```
These parameters allow configuring Apache HttpClient connection pool behaviour by enabling:
eviction of idle connections after a configurable duration
a maximum time-to-live for pooled connections

Without these settings, the HTTP client may reuse stale pooled connections when the
server has already closed the underlying socket (for example due to keep-alive timeout).

In our Bonita deployment this typically occurs when there has been about one hour of
inactivity since the previous API call. The next request attempts to reuse the stale
connection and eventually fails with a timeout.

Example error observed after a connection became stale:
```
java.lang.reflect.UndeclaredThrowableException
    at jdk.proxy2/jdk.proxy2.$Proxy168.login(Unknown Source)
    at org.bonitasoft.engine.api.APIClient.login(APIClient.java:147)
...
Caused by: java.net.SocketException: Operation timed out
    at org.bonitasoft.engine.api.HTTPServerAPI.invokeMethod(HTTPServerAPI.java:143)
```

I tested this running locally and it fixes the issue for us. If this is ok, would it be possible to backport this fix to the 10.2.x maintenance branch as we're not quite ready for an upgrade.